### PR TITLE
Convert to file-scoped namespace

### DIFF
--- a/src/KustoTerminal.CLI/Program.cs
+++ b/src/KustoTerminal.CLI/Program.cs
@@ -12,56 +12,55 @@ using System.Runtime.InteropServices;
 using System.Globalization;
 using System.Threading;
 
-namespace KustoTerminal.CLI
+namespace KustoTerminal.CLI;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
+        try
         {
+            Console.WriteLine("Kusto Terminal - Azure Data Explorer Client");
+            Console.WriteLine("Initializing...");
+
+            // Initialize services
+            var connectionManager = new ConnectionManager();
+            var userSettingsManager = new UserSettingsManager();
+
+            // Load existing connections
+            await connectionManager.LoadConnectionsAsync();
+            var connections = await connectionManager.GetConnectionsAsync();
+
+            SetDateTimeFormatting();
+
+            Console.WriteLine("Starting Terminal UI...");
+
+            Application.Init(driverName: "NetDriver");
+
             try
             {
-                Console.WriteLine("Kusto Terminal - Azure Data Explorer Client");
-                Console.WriteLine("Initializing...");
-
-                // Initialize services
-                var connectionManager = new ConnectionManager();
-                var userSettingsManager = new UserSettingsManager();
-
-                // Load existing connections
-                await connectionManager.LoadConnectionsAsync();
-                var connections = await connectionManager.GetConnectionsAsync();
-
-                SetDateTimeFormatting();
-
-                Console.WriteLine("Starting Terminal UI...");
-
-                Application.Init(driverName: "NetDriver");
-
-                try
-                {
-                    // Start the main window
-                    using var window = MainWindow.Run(connectionManager, userSettingsManager);
-                }
-                finally
-                {
-                    Application.Shutdown();
-                }
+                // Start the main window
+                using var window = MainWindow.Run(connectionManager, userSettingsManager);
             }
-            catch (Exception ex)
+            finally
             {
-                Console.WriteLine($"Fatal error: {ex.ToString()}");
-                Console.WriteLine("Press any key to exit...");
-                Console.ReadKey();
+                Application.Shutdown();
             }
         }
-
-        static void SetDateTimeFormatting()
+        catch (Exception ex)
         {
-            var customCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
-            customCulture.DateTimeFormat.ShortDatePattern = "yyyy-MM-dd";
-            customCulture.DateTimeFormat.LongTimePattern = "HH:mm:ss";
-            Thread.CurrentThread.CurrentCulture = customCulture;
-            Thread.CurrentThread.CurrentUICulture = customCulture; 
+            Console.WriteLine($"Fatal error: {ex.ToString()}");
+            Console.WriteLine("Press any key to exit...");
+            Console.ReadKey();
         }
+    }
+
+    static void SetDateTimeFormatting()
+    {
+        var customCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        customCulture.DateTimeFormat.ShortDatePattern = "yyyy-MM-dd";
+        customCulture.DateTimeFormat.LongTimePattern = "HH:mm:ss";
+        Thread.CurrentThread.CurrentCulture = customCulture;
+        Thread.CurrentThread.CurrentUICulture = customCulture; 
     }
 }

--- a/src/KustoTerminal.Core/Interfaces/IAuthenticationProvider.cs
+++ b/src/KustoTerminal.Core/Interfaces/IAuthenticationProvider.cs
@@ -1,13 +1,11 @@
-using System.Threading.Tasks;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Interfaces
+namespace KustoTerminal.Core.Interfaces;
+
+public interface IAuthenticationProvider
 {
-    public interface IAuthenticationProvider
-    {
-        Task<string> GetAccessTokenAsync(string clusterUri);
-        bool IsAuthenticated();
-        Task<bool> ValidateAuthenticationAsync();
-        AuthenticationType AuthType { get; }
-    }
+    Task<string> GetAccessTokenAsync(string clusterUri);
+    bool IsAuthenticated();
+    Task<bool> ValidateAuthenticationAsync();
+    AuthenticationType AuthType { get; }
 }

--- a/src/KustoTerminal.Core/Interfaces/IConnectionManager.cs
+++ b/src/KustoTerminal.Core/Interfaces/IConnectionManager.cs
@@ -2,19 +2,18 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Interfaces
+namespace KustoTerminal.Core.Interfaces;
+
+public interface IConnectionManager
 {
-    public interface IConnectionManager
-    {
-        Task<IEnumerable<KustoConnection>> GetConnectionsAsync();
-        Task<KustoConnection?> GetConnectionAsync(string id);
-        Task<KustoConnection?> GetDefaultConnectionAsync();
-        Task AddConnectionAsync(KustoConnection connection);
-        Task UpdateConnectionAsync(KustoConnection connection);
-        Task DeleteConnectionAsync(string id);
-        Task SetDefaultConnectionAsync(string id);
-        Task RefreshDatabasesAsync(string connectionId, IKustoClient kustoClient);
-        Task SaveConnectionsAsync();
-        Task LoadConnectionsAsync();
-    }
+    Task<IEnumerable<KustoConnection>> GetConnectionsAsync();
+    Task<KustoConnection?> GetConnectionAsync(string id);
+    Task<KustoConnection?> GetDefaultConnectionAsync();
+    Task AddConnectionAsync(KustoConnection connection);
+    Task UpdateConnectionAsync(KustoConnection connection);
+    Task DeleteConnectionAsync(string id);
+    Task SetDefaultConnectionAsync(string id);
+    Task RefreshDatabasesAsync(string connectionId, IKustoClient kustoClient);
+    Task SaveConnectionsAsync();
+    Task LoadConnectionsAsync();
 }

--- a/src/KustoTerminal.Core/Interfaces/IKustoClient.cs
+++ b/src/KustoTerminal.Core/Interfaces/IKustoClient.cs
@@ -3,15 +3,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Interfaces
+namespace KustoTerminal.Core.Interfaces;
+
+public interface IKustoClient
 {
-    public interface IKustoClient
-    {
-        Task<QueryResult> ExecuteQueryAsync(string query, CancellationToken cancellationToken = default, IProgress<string>? progress = null);
-        Task<bool> TestConnectionAsync();
-        Task<string[]> GetDatabasesAsync();
-        Task<string[]> GetTablesAsync(string database);
-        Task CancelCurrentQueryAsync();
-        void Dispose();
-    }
+    Task<QueryResult> ExecuteQueryAsync(string query, CancellationToken cancellationToken = default, IProgress<string>? progress = null);
+    Task<bool> TestConnectionAsync();
+    Task<string[]> GetDatabasesAsync();
+    Task<string[]> GetTablesAsync(string database);
+    Task CancelCurrentQueryAsync();
+    void Dispose();
 }

--- a/src/KustoTerminal.Core/Interfaces/IUserSettingsManager.cs
+++ b/src/KustoTerminal.Core/Interfaces/IUserSettingsManager.cs
@@ -1,13 +1,12 @@
 using System.Threading.Tasks;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Interfaces
+namespace KustoTerminal.Core.Interfaces;
+
+public interface IUserSettingsManager
 {
-    public interface IUserSettingsManager
-    {
-        Task<UserSettings> LoadSettingsAsync();
-        Task SaveSettingsAsync(UserSettings settings);
-        Task SaveLastQueryAsync(string query);
-        Task<string> GetLastQueryAsync();
-    }
+    Task<UserSettings> LoadSettingsAsync();
+    Task SaveSettingsAsync(UserSettings settings);
+    Task SaveLastQueryAsync(string query);
+    Task<string> GetLastQueryAsync();
 }

--- a/src/KustoTerminal.Core/Models/KustoConnection.cs
+++ b/src/KustoTerminal.Core/Models/KustoConnection.cs
@@ -1,35 +1,34 @@
 using System;
 using System.Collections.Generic;
 
-namespace KustoTerminal.Core.Models
+namespace KustoTerminal.Core.Models;
+
+public class KustoConnection
 {
-    public class KustoConnection
-    {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Name { get; set; } = string.Empty;
-        public string ClusterUri { get; set; } = string.Empty;
-        public string Database { get; set; } = string.Empty;
-        public List<string> Databases { get; set; } = new List<string>();
-        public AuthenticationType AuthType { get; set; } = AuthenticationType.AzureCli;
-        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-        public DateTime LastUsed { get; set; } = DateTime.UtcNow;
-        public bool IsDefault { get; set; } = false;
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Name { get; set; } = string.Empty;
+    public string ClusterUri { get; set; } = string.Empty;
+    public string Database { get; set; } = string.Empty;
+    public List<string> Databases { get; set; } = new List<string>();
+    public AuthenticationType AuthType { get; set; } = AuthenticationType.AzureCli;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime LastUsed { get; set; } = DateTime.UtcNow;
+    public bool IsDefault { get; set; } = false;
 
-        public string DisplayName => !string.IsNullOrEmpty(Name) ? Name : ClusterUri;
-        
-        public bool IsValid()
-        {
-            return !string.IsNullOrWhiteSpace(ClusterUri) && 
-                   !string.IsNullOrWhiteSpace(Database) &&
-                   Uri.TryCreate(ClusterUri, UriKind.Absolute, out _);
-        }
-    }
-
-    public enum AuthenticationType
+    public string DisplayName => !string.IsNullOrEmpty(Name) ? Name : ClusterUri;
+    
+    public bool IsValid()
     {
-        None,
-        AzureCli,
-        ServicePrincipal,
-        Interactive
+        return !string.IsNullOrWhiteSpace(ClusterUri) && 
+               !string.IsNullOrWhiteSpace(Database) &&
+               Uri.TryCreate(ClusterUri, UriKind.Absolute, out _);
     }
+}
+
+public enum AuthenticationType
+{
+    None,
+    AzureCli,
+    ServicePrincipal,
+    Interactive
 }

--- a/src/KustoTerminal.Core/Models/QueryResult.cs
+++ b/src/KustoTerminal.Core/Models/QueryResult.cs
@@ -2,53 +2,52 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 
-namespace KustoTerminal.Core.Models
-{
-    public class QueryResult
-    {
-        public bool IsSuccess { get; set; }
-        public string Query { get; set; } = string.Empty;
-        public TimeSpan Duration { get; set; }
-        public DateTime ExecutedAt { get; set; } = DateTime.UtcNow;
-        public string? ErrorMessage { get; set; }
-        public DataTable? Data { get; set; }
-        public string? ClientRequestId { get; set; }
-        public int RowCount => Data?.Rows.Count ?? 0;
-        public int ColumnCount => Data?.Columns.Count ?? 0;
-        
-        public static QueryResult Success(string query, DataTable data, TimeSpan duration, string? clientRequestId = null)
-        {
-            return new QueryResult
-            {
-                IsSuccess = true,
-                Query = query,
-                Data = data,
-                Duration = duration,
-                ClientRequestId = clientRequestId
-            };
-        }
-        
-        public static QueryResult Error(string query, string errorMessage, TimeSpan duration, string? clientRequestId = null)
-        {
-            return new QueryResult
-            {
-                IsSuccess = false,
-                Query = query,
-                ErrorMessage = errorMessage,
-                Duration = duration,
-                ClientRequestId = clientRequestId
-            };
-        }
-    }
+namespace KustoTerminal.Core.Models;
 
-    public class QueryHistory
+public class QueryResult
+{
+    public bool IsSuccess { get; set; }
+    public string Query { get; set; } = string.Empty;
+    public TimeSpan Duration { get; set; }
+    public DateTime ExecutedAt { get; set; } = DateTime.UtcNow;
+    public string? ErrorMessage { get; set; }
+    public DataTable? Data { get; set; }
+    public string? ClientRequestId { get; set; }
+    public int RowCount => Data?.Rows.Count ?? 0;
+    public int ColumnCount => Data?.Columns.Count ?? 0;
+    
+    public static QueryResult Success(string query, DataTable data, TimeSpan duration, string? clientRequestId = null)
     {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Query { get; set; } = string.Empty;
-        public string ConnectionId { get; set; } = string.Empty;
-        public DateTime ExecutedAt { get; set; } = DateTime.UtcNow;
-        public bool IsSuccessful { get; set; }
-        public TimeSpan Duration { get; set; }
-        public string? ErrorMessage { get; set; }
+        return new QueryResult
+        {
+            IsSuccess = true,
+            Query = query,
+            Data = data,
+            Duration = duration,
+            ClientRequestId = clientRequestId
+        };
     }
+    
+    public static QueryResult Error(string query, string errorMessage, TimeSpan duration, string? clientRequestId = null)
+    {
+        return new QueryResult
+        {
+            IsSuccess = false,
+            Query = query,
+            ErrorMessage = errorMessage,
+            Duration = duration,
+            ClientRequestId = clientRequestId
+        };
+    }
+}
+
+public class QueryHistory
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Query { get; set; } = string.Empty;
+    public string ConnectionId { get; set; } = string.Empty;
+    public DateTime ExecutedAt { get; set; } = DateTime.UtcNow;
+    public bool IsSuccessful { get; set; }
+    public TimeSpan Duration { get; set; }
+    public string? ErrorMessage { get; set; }
 }

--- a/src/KustoTerminal.Core/Models/UserSettings.cs
+++ b/src/KustoTerminal.Core/Models/UserSettings.cs
@@ -1,10 +1,9 @@
 using System;
 
-namespace KustoTerminal.Core.Models
+namespace KustoTerminal.Core.Models;
+
+public class UserSettings
 {
-    public class UserSettings
-    {
-        public string LastQuery { get; set; } = string.Empty;
-        public DateTime LastModified { get; set; } = DateTime.UtcNow;
-    }
+    public string LastQuery { get; set; } = string.Empty;
+    public DateTime LastModified { get; set; } = DateTime.UtcNow;
 }

--- a/src/KustoTerminal.Core/Services/AuthenticationProviderFactory.cs
+++ b/src/KustoTerminal.Core/Services/AuthenticationProviderFactory.cs
@@ -2,18 +2,17 @@ using System;
 using KustoTerminal.Core.Interfaces;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Services
+namespace KustoTerminal.Core.Services;
+
+public static class AuthenticationProviderFactory
 {
-    public static class AuthenticationProviderFactory
+    public static IAuthenticationProvider? CreateProvider(AuthenticationType authType)
     {
-        public static IAuthenticationProvider? CreateProvider(AuthenticationType authType)
+        return authType switch
         {
-            return authType switch
-            {
-                AuthenticationType.None => new NoAuthenticationProvider(),
-                AuthenticationType.AzureCli => new AzureCliAuthenticationProvider(), // Will be handled at higher level
-                _ => throw new ArgumentException($"Unknown authentication type: {authType}", nameof(authType))
-            };
-        }
+            AuthenticationType.None => new NoAuthenticationProvider(),
+            AuthenticationType.AzureCli => new AzureCliAuthenticationProvider(), // Will be handled at higher level
+            _ => throw new ArgumentException($"Unknown authentication type: {authType}", nameof(authType))
+        };
     }
 }

--- a/src/KustoTerminal.Core/Services/AzureCliAuthenticationProvider.cs
+++ b/src/KustoTerminal.Core/Services/AzureCliAuthenticationProvider.cs
@@ -6,78 +6,77 @@ using Azure.Identity;
 using KustoTerminal.Core.Interfaces;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Services
+namespace KustoTerminal.Core.Services;
+
+public class AzureCliAuthenticationProvider : IAuthenticationProvider
 {
-    public class AzureCliAuthenticationProvider : IAuthenticationProvider
+    private readonly AzureCliCredential _credential;
+    private readonly string[] _scopes = { "https://kusto.kusto.windows.net/.default" };
+
+    public AuthenticationType AuthType => AuthenticationType.AzureCli;
+
+    public AzureCliAuthenticationProvider()
     {
-        private readonly AzureCliCredential _credential;
-        private readonly string[] _scopes = { "https://kusto.kusto.windows.net/.default" };
+        _credential = new AzureCliCredential();
+    }
 
-        public AuthenticationType AuthType => AuthenticationType.AzureCli;
-
-        public AzureCliAuthenticationProvider()
+    public async Task<string> GetAccessTokenAsync(string clusterUri)
+    {
+        try
         {
-            _credential = new AzureCliCredential();
+            var tokenRequestContext = new TokenRequestContext(_scopes);
+            var token = await _credential.GetTokenAsync(tokenRequestContext);
+            return token.Token;
         }
-
-        public async Task<string> GetAccessTokenAsync(string clusterUri)
+        catch (CredentialUnavailableException ex)
         {
-            try
-            {
-                var tokenRequestContext = new TokenRequestContext(_scopes);
-                var token = await _credential.GetTokenAsync(tokenRequestContext);
-                return token.Token;
-            }
-            catch (CredentialUnavailableException ex)
-            {
-                throw new InvalidOperationException(
-                    "Azure CLI authentication is not available. Please run 'az login' first.", ex);
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException(
-                    $"Failed to get access token from Azure CLI: {ex.Message}", ex);
-            }
+            throw new InvalidOperationException(
+                "Azure CLI authentication is not available. Please run 'az login' first.", ex);
         }
-
-        public bool IsAuthenticated()
+        catch (Exception ex)
         {
-            try
+            throw new InvalidOperationException(
+                $"Failed to get access token from Azure CLI: {ex.Message}", ex);
+        }
+    }
+
+    public bool IsAuthenticated()
+    {
+        try
+        {
+            var process = new Process
             {
-                var process = new Process
+                StartInfo = new ProcessStartInfo
                 {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = "az",
-                        Arguments = "account show",
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        CreateNoWindow = true
-                    }
-                };
+                    FileName = "az",
+                    Arguments = "account show",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                }
+            };
 
-                process.Start();
-                process.WaitForExit();
-                return process.ExitCode == 0;
-            }
-            catch
-            {
-                return false;
-            }
+            process.Start();
+            process.WaitForExit();
+            return process.ExitCode == 0;
         }
-
-        public async Task<bool> ValidateAuthenticationAsync()
+        catch
         {
-            try
-            {
-                await GetAccessTokenAsync("https://help.kusto.windows.net");
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
+            return false;
+        }
+    }
+
+    public async Task<bool> ValidateAuthenticationAsync()
+    {
+        try
+        {
+            await GetAccessTokenAsync("https://help.kusto.windows.net");
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 }

--- a/src/KustoTerminal.Core/Services/ConnectionManager.cs
+++ b/src/KustoTerminal.Core/Services/ConnectionManager.cs
@@ -7,44 +7,64 @@ using Newtonsoft.Json;
 using KustoTerminal.Core.Interfaces;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Services
+namespace KustoTerminal.Core.Services;
+
+public class ConnectionManager : IConnectionManager
 {
-    public class ConnectionManager : IConnectionManager
+    private readonly string _configFilePath;
+    private List<KustoConnection> _connections;
+
+    public ConnectionManager()
     {
-        private readonly string _configFilePath;
-        private List<KustoConnection> _connections;
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var appFolder = Path.Combine(appDataPath, "KustoTerminal");
+        Directory.CreateDirectory(appFolder);
+        _configFilePath = Path.Combine(appFolder, "connections.json");
+        _connections = new List<KustoConnection>();
+    }
 
-        public ConnectionManager()
+    public async Task<IEnumerable<KustoConnection>> GetConnectionsAsync()
+    {
+        await LoadConnectionsAsync();
+        return _connections.AsReadOnly();
+    }
+
+    public async Task<KustoConnection?> GetConnectionAsync(string id)
+    {
+        await LoadConnectionsAsync();
+        return _connections.FirstOrDefault(c => c.Id == id);
+    }
+
+    public async Task<KustoConnection?> GetDefaultConnectionAsync()
+    {
+        await LoadConnectionsAsync();
+        return _connections.FirstOrDefault(c => c.IsDefault) ?? _connections.FirstOrDefault();
+    }
+
+    public async Task AddConnectionAsync(KustoConnection connection)
+    {
+        await LoadConnectionsAsync();
+        
+        if (connection.IsDefault)
         {
-            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var appFolder = Path.Combine(appDataPath, "KustoTerminal");
-            Directory.CreateDirectory(appFolder);
-            _configFilePath = Path.Combine(appFolder, "connections.json");
-            _connections = new List<KustoConnection>();
+            // Ensure only one default connection
+            foreach (var conn in _connections)
+            {
+                conn.IsDefault = false;
+            }
         }
+        
+        _connections.Add(connection);
+        await SaveConnectionsAsync();
+    }
 
-        public async Task<IEnumerable<KustoConnection>> GetConnectionsAsync()
+    public async Task UpdateConnectionAsync(KustoConnection connection)
+    {
+        await LoadConnectionsAsync();
+        
+        var existingIndex = _connections.FindIndex(c => c.Id == connection.Id);
+        if (existingIndex >= 0)
         {
-            await LoadConnectionsAsync();
-            return _connections.AsReadOnly();
-        }
-
-        public async Task<KustoConnection?> GetConnectionAsync(string id)
-        {
-            await LoadConnectionsAsync();
-            return _connections.FirstOrDefault(c => c.Id == id);
-        }
-
-        public async Task<KustoConnection?> GetDefaultConnectionAsync()
-        {
-            await LoadConnectionsAsync();
-            return _connections.FirstOrDefault(c => c.IsDefault) ?? _connections.FirstOrDefault();
-        }
-
-        public async Task AddConnectionAsync(KustoConnection connection)
-        {
-            await LoadConnectionsAsync();
-            
             if (connection.IsDefault)
             {
                 // Ensure only one default connection
@@ -54,115 +74,94 @@ namespace KustoTerminal.Core.Services
                 }
             }
             
-            _connections.Add(connection);
+            _connections[existingIndex] = connection;
             await SaveConnectionsAsync();
         }
+    }
 
-        public async Task UpdateConnectionAsync(KustoConnection connection)
+    public async Task DeleteConnectionAsync(string id)
+    {
+        await LoadConnectionsAsync();
+        
+        var connectionToRemove = _connections.FirstOrDefault(c => c.Id == id);
+        if (connectionToRemove != null)
         {
-            await LoadConnectionsAsync();
+            _connections.Remove(connectionToRemove);
             
-            var existingIndex = _connections.FindIndex(c => c.Id == connection.Id);
-            if (existingIndex >= 0)
+            // If we removed the default connection, make the first one default
+            if (connectionToRemove.IsDefault && _connections.Any())
             {
-                if (connection.IsDefault)
-                {
-                    // Ensure only one default connection
-                    foreach (var conn in _connections)
-                    {
-                        conn.IsDefault = false;
-                    }
-                }
-                
-                _connections[existingIndex] = connection;
-                await SaveConnectionsAsync();
-            }
-        }
-
-        public async Task DeleteConnectionAsync(string id)
-        {
-            await LoadConnectionsAsync();
-            
-            var connectionToRemove = _connections.FirstOrDefault(c => c.Id == id);
-            if (connectionToRemove != null)
-            {
-                _connections.Remove(connectionToRemove);
-                
-                // If we removed the default connection, make the first one default
-                if (connectionToRemove.IsDefault && _connections.Any())
-                {
-                    _connections.First().IsDefault = true;
-                }
-                
-                await SaveConnectionsAsync();
-            }
-        }
-
-        public async Task SetDefaultConnectionAsync(string id)
-        {
-            await LoadConnectionsAsync();
-            
-            foreach (var connection in _connections)
-            {
-                connection.IsDefault = connection.Id == id;
+                _connections.First().IsDefault = true;
             }
             
             await SaveConnectionsAsync();
         }
+    }
 
-        public async Task RefreshDatabasesAsync(string connectionId, IKustoClient kustoClient)
+    public async Task SetDefaultConnectionAsync(string id)
+    {
+        await LoadConnectionsAsync();
+        
+        foreach (var connection in _connections)
         {
-            await LoadConnectionsAsync();
-            
-            var connection = _connections.FirstOrDefault(c => c.Id == connectionId);
-            if (connection != null)
-            {
-                try
-                {
-                    var databases = await kustoClient.GetDatabasesAsync();
-                    connection.Databases = databases.ToList();
-                    await SaveConnectionsAsync();
-                }
-                catch
-                {
-                    // If we can't refresh databases, keep the existing list
-                    // This could happen due to network issues or permissions
-                }
-            }
+            connection.IsDefault = connection.Id == id;
         }
+        
+        await SaveConnectionsAsync();
+    }
 
-        public async Task SaveConnectionsAsync()
+    public async Task RefreshDatabasesAsync(string connectionId, IKustoClient kustoClient)
+    {
+        await LoadConnectionsAsync();
+        
+        var connection = _connections.FirstOrDefault(c => c.Id == connectionId);
+        if (connection != null)
         {
             try
             {
-                var json = JsonConvert.SerializeObject(_connections, Formatting.Indented);
-                await File.WriteAllTextAsync(_configFilePath, json);
+                var databases = await kustoClient.GetDatabasesAsync();
+                connection.Databases = databases.ToList();
+                await SaveConnectionsAsync();
             }
-            catch (Exception ex)
+            catch
             {
-                throw new InvalidOperationException($"Failed to save connections: {ex.Message}", ex);
+                // If we can't refresh databases, keep the existing list
+                // This could happen due to network issues or permissions
             }
         }
+    }
 
-        public async Task LoadConnectionsAsync()
+    public async Task SaveConnectionsAsync()
+    {
+        try
         {
-            try
+            var json = JsonConvert.SerializeObject(_connections, Formatting.Indented);
+            await File.WriteAllTextAsync(_configFilePath, json);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to save connections: {ex.Message}", ex);
+        }
+    }
+
+    public async Task LoadConnectionsAsync()
+    {
+        try
+        {
+            if (File.Exists(_configFilePath))
             {
-                if (File.Exists(_configFilePath))
-                {
-                    var json = await File.ReadAllTextAsync(_configFilePath);
-                    var connections = JsonConvert.DeserializeObject<List<KustoConnection>>(json);
-                    _connections = connections ?? new List<KustoConnection>();
-                }
-                else
-                {
-                    _connections = new List<KustoConnection>();
-                }
+                var json = await File.ReadAllTextAsync(_configFilePath);
+                var connections = JsonConvert.DeserializeObject<List<KustoConnection>>(json);
+                _connections = connections ?? new List<KustoConnection>();
             }
-            catch (Exception ex)
+            else
             {
-                throw new InvalidOperationException($"Failed to load connections: {ex.Message}", ex);
+                _connections = new List<KustoConnection>();
             }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to load connections: {ex.Message}", ex);
         }
     }
 }

--- a/src/KustoTerminal.Core/Services/KustoClient.cs
+++ b/src/KustoTerminal.Core/Services/KustoClient.cs
@@ -10,286 +10,285 @@ using Kusto.Data.Net.Client;
 using KustoTerminal.Core.Interfaces;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Services
+namespace KustoTerminal.Core.Services;
+
+public class KustoClient : IKustoClient
 {
-    public class KustoClient : IKustoClient
+    private readonly KustoConnection _connection;
+    private readonly IAuthenticationProvider _authProvider;
+    private ICslQueryProvider? _queryProvider;
+    private ICslAdminProvider? _adminProvider;
+    private string? _currentRequestId;
+    private CancellationTokenSource? _internalCancellationSource;
+
+    public KustoClient(KustoConnection connection, IAuthenticationProvider authProvider)
     {
-        private readonly KustoConnection _connection;
-        private readonly IAuthenticationProvider _authProvider;
-        private ICslQueryProvider? _queryProvider;
-        private ICslAdminProvider? _adminProvider;
-        private string? _currentRequestId;
-        private CancellationTokenSource? _internalCancellationSource;
+        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        _authProvider = authProvider ?? throw new ArgumentNullException(nameof(authProvider));
+    }
 
-        public KustoClient(KustoConnection connection, IAuthenticationProvider authProvider)
+    public async Task<QueryResult> ExecuteQueryAsync(string query, CancellationToken cancellationToken = default, IProgress<string>? progress = null)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        
+        // Clean up any previous internal cancellation source
+        _internalCancellationSource?.Dispose();
+        _internalCancellationSource = new CancellationTokenSource();
+        
+        // Combine external cancellation token with internal one
+        var combinedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, _internalCancellationSource.Token);
+        var combinedToken = combinedCancellationSource.Token;
+        
+        try
         {
-            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-            _authProvider = authProvider ?? throw new ArgumentNullException(nameof(authProvider));
-        }
-
-        public async Task<QueryResult> ExecuteQueryAsync(string query, CancellationToken cancellationToken = default, IProgress<string>? progress = null)
-        {
-            var stopwatch = Stopwatch.StartNew();
+            progress?.Report("Initializing connection...");
+            await EnsureConnectionAsync();
             
-            // Clean up any previous internal cancellation source
-            _internalCancellationSource?.Dispose();
-            _internalCancellationSource = new CancellationTokenSource();
+            // Check for cancellation after connection setup
+            combinedToken.ThrowIfCancellationRequested();
             
-            // Combine external cancellation token with internal one
-            var combinedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
-                cancellationToken, _internalCancellationSource.Token);
-            var combinedToken = combinedCancellationSource.Token;
+            // Determine if this is a command (starts with dot) or a query
+            var isCommand = query.TrimStart().StartsWith(".");
             
-            try
-            {
-                progress?.Report("Initializing connection...");
-                await EnsureConnectionAsync();
-                
-                // Check for cancellation after connection setup
-                combinedToken.ThrowIfCancellationRequested();
-                
-                // Determine if this is a command (starts with dot) or a query
-                var isCommand = query.TrimStart().StartsWith(".");
-                
-                if (isCommand && _adminProvider == null)
-                    throw new InvalidOperationException("Admin provider is not initialized");
-                else if (!isCommand && _queryProvider == null)
-                    throw new InvalidOperationException("Query provider is not initialized");
+            if (isCommand && _adminProvider == null)
+                throw new InvalidOperationException("Admin provider is not initialized");
+            else if (!isCommand && _queryProvider == null)
+                throw new InvalidOperationException("Query provider is not initialized");
 
-                progress?.Report(isCommand ? "Preparing command..." : "Preparing query...");
-                var clientRequestProperties = new ClientRequestProperties();
+            progress?.Report(isCommand ? "Preparing command..." : "Preparing query...");
+            var clientRequestProperties = new ClientRequestProperties();
 
-                // Always set up request ID for potential cancellation
-                _currentRequestId = $"KustoTerminal;{Guid.NewGuid().ToString()}";
-                clientRequestProperties.ClientRequestId = _currentRequestId;
-                
-                // Set up cancellation monitoring
-                var cancellationMonitorTask = MonitorCancellationAsync(combinedToken, progress);
-                
-                // Check for cancellation before executing query/command
-                combinedToken.ThrowIfCancellationRequested();
-                
-                progress?.Report(isCommand ? "Executing command..." : "Executing query...");
-                
-                // Execute query or command based on whether it starts with a dot
-                IDataReader reader;
-                if (isCommand)
-                {
-                    reader = await _adminProvider!.ExecuteControlCommandAsync(_connection.Database, query, clientRequestProperties);
-                }
-                else
-                {
-                    reader = await _queryProvider!.ExecuteQueryAsync(_connection.Database, query, clientRequestProperties);
-                }
-                
-                // Check for cancellation after query/command execution
-                combinedToken.ThrowIfCancellationRequested();
-                
-                progress?.Report("Processing results...");
-                var dataTable = new DataTable();
-                
-                // Load data with cancellation checks
-                await Task.Run(() =>
-                {
-                    dataTable.Load(reader);
-                }, combinedToken);
-                
-                progress?.Report(isCommand ? "Command completed successfully" : "Query completed successfully");
-                stopwatch.Stop();
-                return QueryResult.Success(query, dataTable, stopwatch.Elapsed, _currentRequestId);
-            }
-            catch (OperationCanceledException)
-            {
-                stopwatch.Stop();
-                progress?.Report("Cancelling query on server...");
-                
-                // Cancel the query on the server side using .cancel query command
-                await CancelQueryOnServerAsync();
-                
-                progress?.Report("Query cancelled");
-                return QueryResult.Error(query, "Query was cancelled", stopwatch.Elapsed, _currentRequestId);
-            }
-            catch (Exception ex)
-            {
-                stopwatch.Stop();
-                progress?.Report($"Query failed: {ex.Message}");
-                return QueryResult.Error(query, ex.Message, stopwatch.Elapsed, _currentRequestId);
-            }
-            finally
-            {
-                combinedCancellationSource?.Dispose();
-                _currentRequestId = null;
-            }
-        }
-
-        private async Task MonitorCancellationAsync(CancellationToken cancellationToken, IProgress<string>? progress)
-        {
-            try
-            {
-                await Task.Delay(Timeout.Infinite, cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                // When cancellation is requested, immediately try to cancel on server
-                progress?.Report("Cancellation requested, stopping query...");
-                await CancelQueryOnServerAsync();
-            }
-        }
-
-        private async Task CancelQueryOnServerAsync()
-        {
-            if (string.IsNullOrEmpty(_currentRequestId) || _adminProvider == null)
-                return;
-
-            try
-            {
-                var cancelCommand = $".cancel query '{_currentRequestId}'";
-                var cancelProperties = new ClientRequestProperties();
-                
-                // Execute the cancel command with a short timeout
-                await _adminProvider.ExecuteControlCommandAsync(_connection.Database, cancelCommand, cancelProperties);
-            }
-            catch
-            {
-                // Ignore errors when trying to cancel - the query might have already completed
-                // or there might be permission issues
-            }
-        }
-
-        public Task CancelCurrentQueryAsync()
-        {
-            if (_internalCancellationSource != null && !_internalCancellationSource.Token.IsCancellationRequested)
-            {
-                _internalCancellationSource.Cancel();
-            }
+            // Always set up request ID for potential cancellation
+            _currentRequestId = $"KustoTerminal;{Guid.NewGuid().ToString()}";
+            clientRequestProperties.ClientRequestId = _currentRequestId;
             
-            // Fire-and-forget server cancellation to avoid blocking
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    await CancelQueryOnServerAsync();
-                }
-                catch (Exception ex)
-                {
-                    // Log but don't throw - cancellation errors shouldn't affect anything
-                    Console.WriteLine($"Warning: Server-side query cancellation failed: {ex.Message}");
-                }
-            });
+            // Set up cancellation monitoring
+            var cancellationMonitorTask = MonitorCancellationAsync(combinedToken, progress);
             
-            return Task.CompletedTask;
-        }
-
-        public async Task<bool> TestConnectionAsync()
-        {
-            try
-            {
-                await EnsureConnectionAsync();
-                
-                if (_queryProvider == null)
-                    return false;
-
-                // Simple test query
-                var testQuery = ".show version";
-                var clientRequestProperties = new ClientRequestProperties();
-                using var reader = await _queryProvider.ExecuteQueryAsync(_connection.Database, testQuery, clientRequestProperties);
-                
-                return reader != null;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        public async Task<string[]> GetDatabasesAsync()
-        {
-            try
-            {
-                await EnsureConnectionAsync();
-                
-                if (_adminProvider == null)
-                    throw new InvalidOperationException("Admin provider is not initialized");
-
-                var query = ".show databases";
-                var clientRequestProperties = new ClientRequestProperties();
-                using var reader = await _adminProvider.ExecuteControlCommandAsync(_connection.Database, query, clientRequestProperties);
-                
-                var databases = new List<string>();
-                while (reader.Read())
-                {
-                    if (reader["DatabaseName"] != null)
-                    {
-                        databases.Add(reader["DatabaseName"].ToString() ?? string.Empty);
-                    }
-                }
-                
-                return databases.ToArray();
-            }
-            catch
-            {
-                return Array.Empty<string>();
-            }
-        }
-
-        public async Task<string[]> GetTablesAsync(string database)
-        {
-            try
-            {
-                await EnsureConnectionAsync();
-                
-                if (_queryProvider == null)
-                    throw new InvalidOperationException("Query provider is not initialized");
-
-                var query = ".show tables";
-                var clientRequestProperties = new ClientRequestProperties();
-                using var reader = await _queryProvider.ExecuteQueryAsync(database, query, clientRequestProperties);
-                
-                var tables = new List<string>();
-                while (reader.Read())
-                {
-                    if (reader["TableName"] != null)
-                    {
-                        tables.Add(reader["TableName"].ToString() ?? string.Empty);
-                    }
-                }
-                
-                return tables.ToArray();
-            }
-            catch
-            {
-                return Array.Empty<string>();
-            }
-        }
-
-        private async Task EnsureConnectionAsync()
-        {
-            if (_queryProvider != null && _adminProvider != null)
-                return;
-
-            KustoConnectionStringBuilder connectionStringBuilder;
+            // Check for cancellation before executing query/command
+            combinedToken.ThrowIfCancellationRequested();
             
-            if (_connection.AuthType == AuthenticationType.None)
+            progress?.Report(isCommand ? "Executing command..." : "Executing query...");
+            
+            // Execute query or command based on whether it starts with a dot
+            IDataReader reader;
+            if (isCommand)
             {
-                // For unauthenticated connections, create a connection string without authentication
-                connectionStringBuilder = new KustoConnectionStringBuilder(_connection.ClusterUri);
+                reader = await _adminProvider!.ExecuteControlCommandAsync(_connection.Database, query, clientRequestProperties);
             }
             else
             {
-                // For authenticated connections, get token and use it
-                var token = await _authProvider.GetAccessTokenAsync(_connection.ClusterUri);
-                connectionStringBuilder = new KustoConnectionStringBuilder(_connection.ClusterUri)
-                    .WithAadUserTokenAuthentication(token);
+                reader = await _queryProvider!.ExecuteQueryAsync(_connection.Database, query, clientRequestProperties);
             }
-
-            _queryProvider = KustoClientFactory.CreateCslQueryProvider(connectionStringBuilder);
-            _adminProvider = KustoClientFactory.CreateCslAdminProvider(connectionStringBuilder);
+            
+            // Check for cancellation after query/command execution
+            combinedToken.ThrowIfCancellationRequested();
+            
+            progress?.Report("Processing results...");
+            var dataTable = new DataTable();
+            
+            // Load data with cancellation checks
+            await Task.Run(() =>
+            {
+                dataTable.Load(reader);
+            }, combinedToken);
+            
+            progress?.Report(isCommand ? "Command completed successfully" : "Query completed successfully");
+            stopwatch.Stop();
+            return QueryResult.Success(query, dataTable, stopwatch.Elapsed, _currentRequestId);
         }
-
-        public void Dispose()
+        catch (OperationCanceledException)
         {
-            _queryProvider?.Dispose();
-            _adminProvider?.Dispose();
+            stopwatch.Stop();
+            progress?.Report("Cancelling query on server...");
+            
+            // Cancel the query on the server side using .cancel query command
+            await CancelQueryOnServerAsync();
+            
+            progress?.Report("Query cancelled");
+            return QueryResult.Error(query, "Query was cancelled", stopwatch.Elapsed, _currentRequestId);
         }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            progress?.Report($"Query failed: {ex.Message}");
+            return QueryResult.Error(query, ex.Message, stopwatch.Elapsed, _currentRequestId);
+        }
+        finally
+        {
+            combinedCancellationSource?.Dispose();
+            _currentRequestId = null;
+        }
+    }
+
+    private async Task MonitorCancellationAsync(CancellationToken cancellationToken, IProgress<string>? progress)
+    {
+        try
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // When cancellation is requested, immediately try to cancel on server
+            progress?.Report("Cancellation requested, stopping query...");
+            await CancelQueryOnServerAsync();
+        }
+    }
+
+    private async Task CancelQueryOnServerAsync()
+    {
+        if (string.IsNullOrEmpty(_currentRequestId) || _adminProvider == null)
+            return;
+
+        try
+        {
+            var cancelCommand = $".cancel query '{_currentRequestId}'";
+            var cancelProperties = new ClientRequestProperties();
+            
+            // Execute the cancel command with a short timeout
+            await _adminProvider.ExecuteControlCommandAsync(_connection.Database, cancelCommand, cancelProperties);
+        }
+        catch
+        {
+            // Ignore errors when trying to cancel - the query might have already completed
+            // or there might be permission issues
+        }
+    }
+
+    public Task CancelCurrentQueryAsync()
+    {
+        if (_internalCancellationSource != null && !_internalCancellationSource.Token.IsCancellationRequested)
+        {
+            _internalCancellationSource.Cancel();
+        }
+        
+        // Fire-and-forget server cancellation to avoid blocking
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await CancelQueryOnServerAsync();
+            }
+            catch (Exception ex)
+            {
+                // Log but don't throw - cancellation errors shouldn't affect anything
+                Console.WriteLine($"Warning: Server-side query cancellation failed: {ex.Message}");
+            }
+        });
+        
+        return Task.CompletedTask;
+    }
+
+    public async Task<bool> TestConnectionAsync()
+    {
+        try
+        {
+            await EnsureConnectionAsync();
+            
+            if (_queryProvider == null)
+                return false;
+
+            // Simple test query
+            var testQuery = ".show version";
+            var clientRequestProperties = new ClientRequestProperties();
+            using var reader = await _queryProvider.ExecuteQueryAsync(_connection.Database, testQuery, clientRequestProperties);
+            
+            return reader != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<string[]> GetDatabasesAsync()
+    {
+        try
+        {
+            await EnsureConnectionAsync();
+            
+            if (_adminProvider == null)
+                throw new InvalidOperationException("Admin provider is not initialized");
+
+            var query = ".show databases";
+            var clientRequestProperties = new ClientRequestProperties();
+            using var reader = await _adminProvider.ExecuteControlCommandAsync(_connection.Database, query, clientRequestProperties);
+            
+            var databases = new List<string>();
+            while (reader.Read())
+            {
+                if (reader["DatabaseName"] != null)
+                {
+                    databases.Add(reader["DatabaseName"].ToString() ?? string.Empty);
+                }
+            }
+            
+            return databases.ToArray();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    public async Task<string[]> GetTablesAsync(string database)
+    {
+        try
+        {
+            await EnsureConnectionAsync();
+            
+            if (_queryProvider == null)
+                throw new InvalidOperationException("Query provider is not initialized");
+
+            var query = ".show tables";
+            var clientRequestProperties = new ClientRequestProperties();
+            using var reader = await _queryProvider.ExecuteQueryAsync(database, query, clientRequestProperties);
+            
+            var tables = new List<string>();
+            while (reader.Read())
+            {
+                if (reader["TableName"] != null)
+                {
+                    tables.Add(reader["TableName"].ToString() ?? string.Empty);
+                }
+            }
+            
+            return tables.ToArray();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    private async Task EnsureConnectionAsync()
+    {
+        if (_queryProvider != null && _adminProvider != null)
+            return;
+
+        KustoConnectionStringBuilder connectionStringBuilder;
+        
+        if (_connection.AuthType == AuthenticationType.None)
+        {
+            // For unauthenticated connections, create a connection string without authentication
+            connectionStringBuilder = new KustoConnectionStringBuilder(_connection.ClusterUri);
+        }
+        else
+        {
+            // For authenticated connections, get token and use it
+            var token = await _authProvider.GetAccessTokenAsync(_connection.ClusterUri);
+            connectionStringBuilder = new KustoConnectionStringBuilder(_connection.ClusterUri)
+                .WithAadUserTokenAuthentication(token);
+        }
+
+        _queryProvider = KustoClientFactory.CreateCslQueryProvider(connectionStringBuilder);
+        _adminProvider = KustoClientFactory.CreateCslAdminProvider(connectionStringBuilder);
+    }
+
+    public void Dispose()
+    {
+        _queryProvider?.Dispose();
+        _adminProvider?.Dispose();
     }
 }

--- a/src/KustoTerminal.Core/Services/NoAuthenticationProvider.cs
+++ b/src/KustoTerminal.Core/Services/NoAuthenticationProvider.cs
@@ -3,28 +3,27 @@ using System.Threading.Tasks;
 using KustoTerminal.Core.Interfaces;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Services
+namespace KustoTerminal.Core.Services;
+
+public class NoAuthenticationProvider : IAuthenticationProvider
 {
-    public class NoAuthenticationProvider : IAuthenticationProvider
+    public AuthenticationType AuthType => AuthenticationType.None;
+
+    public Task<string> GetAccessTokenAsync(string clusterUri)
     {
-        public AuthenticationType AuthType => AuthenticationType.None;
+        // Return empty string for unauthenticated connections
+        return Task.FromResult(string.Empty);
+    }
 
-        public Task<string> GetAccessTokenAsync(string clusterUri)
-        {
-            // Return empty string for unauthenticated connections
-            return Task.FromResult(string.Empty);
-        }
+    public bool IsAuthenticated()
+    {
+        // For unauthenticated connections, we're always "authenticated" (no auth required)
+        return true;
+    }
 
-        public bool IsAuthenticated()
-        {
-            // For unauthenticated connections, we're always "authenticated" (no auth required)
-            return true;
-        }
-
-        public Task<bool> ValidateAuthenticationAsync()
-        {
-            // For unauthenticated connections, validation always succeeds
-            return Task.FromResult(true);
-        }
+    public Task<bool> ValidateAuthenticationAsync()
+    {
+        // For unauthenticated connections, validation always succeeds
+        return Task.FromResult(true);
     }
 }

--- a/src/KustoTerminal.Core/Services/UserSettingsManager.cs
+++ b/src/KustoTerminal.Core/Services/UserSettingsManager.cs
@@ -5,77 +5,76 @@ using Newtonsoft.Json;
 using KustoTerminal.Core.Interfaces;
 using KustoTerminal.Core.Models;
 
-namespace KustoTerminal.Core.Services
+namespace KustoTerminal.Core.Services;
+
+public class UserSettingsManager : IUserSettingsManager
 {
-    public class UserSettingsManager : IUserSettingsManager
+    private readonly string _settingsFilePath;
+    private UserSettings? _cachedSettings;
+
+    public UserSettingsManager()
     {
-        private readonly string _settingsFilePath;
-        private UserSettings? _cachedSettings;
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var appFolder = Path.Combine(appDataPath, "KustoTerminal");
+        Directory.CreateDirectory(appFolder);
+        _settingsFilePath = Path.Combine(appFolder, "user-settings.json");
+    }
 
-        public UserSettingsManager()
+    public async Task<UserSettings> LoadSettingsAsync()
+    {
+        if (_cachedSettings != null)
         {
-            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var appFolder = Path.Combine(appDataPath, "KustoTerminal");
-            Directory.CreateDirectory(appFolder);
-            _settingsFilePath = Path.Combine(appFolder, "user-settings.json");
-        }
-
-        public async Task<UserSettings> LoadSettingsAsync()
-        {
-            if (_cachedSettings != null)
-            {
-                return _cachedSettings;
-            }
-
-            try
-            {
-                if (File.Exists(_settingsFilePath))
-                {
-                    var json = await File.ReadAllTextAsync(_settingsFilePath);
-                    _cachedSettings = JsonConvert.DeserializeObject<UserSettings>(json) ?? new UserSettings();
-                }
-                else
-                {
-                    _cachedSettings = new UserSettings();
-                }
-            }
-            catch (Exception ex)
-            {
-                // If we can't load settings, create new ones and log the error
-                _cachedSettings = new UserSettings();
-                // Consider logging the error in a real application
-                Console.WriteLine($"Warning: Failed to load user settings: {ex.Message}");
-            }
-
             return _cachedSettings;
         }
 
-        public async Task SaveSettingsAsync(UserSettings settings)
+        try
         {
-            try
+            if (File.Exists(_settingsFilePath))
             {
-                settings.LastModified = DateTime.UtcNow;
-                var json = JsonConvert.SerializeObject(settings, Formatting.Indented);
-                await File.WriteAllTextAsync(_settingsFilePath, json);
-                _cachedSettings = settings;
+                var json = await File.ReadAllTextAsync(_settingsFilePath);
+                _cachedSettings = JsonConvert.DeserializeObject<UserSettings>(json) ?? new UserSettings();
             }
-            catch (Exception ex)
+            else
             {
-                throw new InvalidOperationException($"Failed to save user settings: {ex.Message}", ex);
+                _cachedSettings = new UserSettings();
             }
         }
-
-        public async Task SaveLastQueryAsync(string query)
+        catch (Exception ex)
         {
-            var settings = await LoadSettingsAsync();
-            settings.LastQuery = query ?? string.Empty;
-            await SaveSettingsAsync(settings);
+            // If we can't load settings, create new ones and log the error
+            _cachedSettings = new UserSettings();
+            // Consider logging the error in a real application
+            Console.WriteLine($"Warning: Failed to load user settings: {ex.Message}");
         }
 
-        public async Task<string> GetLastQueryAsync()
+        return _cachedSettings;
+    }
+
+    public async Task SaveSettingsAsync(UserSettings settings)
+    {
+        try
         {
-            var settings = await LoadSettingsAsync();
-            return settings.LastQuery ?? string.Empty;
+            settings.LastModified = DateTime.UtcNow;
+            var json = JsonConvert.SerializeObject(settings, Formatting.Indented);
+            await File.WriteAllTextAsync(_settingsFilePath, json);
+            _cachedSettings = settings;
         }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to save user settings: {ex.Message}", ex);
+        }
+    }
+
+    public async Task SaveLastQueryAsync(string query)
+    {
+        var settings = await LoadSettingsAsync();
+        settings.LastQuery = query ?? string.Empty;
+        await SaveSettingsAsync(settings);
+    }
+
+    public async Task<string> GetLastQueryAsync()
+    {
+        var settings = await LoadSettingsAsync();
+        return settings.LastQuery ?? string.Empty;
     }
 }

--- a/src/KustoTerminal.UI/Dialogs/ColumnSelectorDialog.cs
+++ b/src/KustoTerminal.UI/Dialogs/ColumnSelectorDialog.cs
@@ -10,176 +10,175 @@ using Terminal.Gui.ViewBase;
 using Terminal.Gui.Input;
 using Terminal.Gui.Drivers;
 
-namespace KustoTerminal.UI.Dialogs
+namespace KustoTerminal.UI.Dialogs;
+
+public class ColumnSelectorDialog : Dialog
 {
-    public class ColumnSelectorDialog : Dialog
+    private ListView _columnsList;
+    private Label _shortcutsLabel;
+    private Label _instructionLabel;
+    private readonly DataTable _dataTable;
+    private readonly HashSet<string> _selectedColumns;
+
+    public HashSet<string> SelectedColumns => _selectedColumns;
+
+    public ColumnSelectorDialog(DataTable dataTable, HashSet<string>? currentSelection = null)
     {
-        private ListView _columnsList;
-        private Label _shortcutsLabel;
-        private Label _instructionLabel;
-        private readonly DataTable _dataTable;
-        private readonly HashSet<string> _selectedColumns;
+        _dataTable = dataTable ?? throw new ArgumentNullException(nameof(dataTable));
+        _selectedColumns = currentSelection != null ? new HashSet<string>(currentSelection) : new HashSet<string>();
 
-        public HashSet<string> SelectedColumns => _selectedColumns;
-
-        public ColumnSelectorDialog(DataTable dataTable, HashSet<string>? currentSelection = null)
+        // If no columns are currently selected, select all by default
+        if (_selectedColumns.Count == 0)
         {
-            _dataTable = dataTable ?? throw new ArgumentNullException(nameof(dataTable));
-            _selectedColumns = currentSelection != null ? new HashSet<string>(currentSelection) : new HashSet<string>();
-
-            // If no columns are currently selected, select all by default
-            if (_selectedColumns.Count == 0)
-            {
-                foreach (DataColumn column in _dataTable.Columns)
-                {
-                    _selectedColumns.Add(column.ColumnName);
-                }
-            }
-
-            Title = "Select Columns to Display";
-            Width = 60;
-            Height = Math.Min(30, _dataTable.Columns.Count + 8);
-
-            InitializeComponents();
-            SetupLayout();
-            SetKeyboard();
-        }
-
-        private void InitializeComponents()
-        {
-            _instructionLabel = new Label()
-            {
-                Text = "Use Space to toggle column selection:",
-                X = 1,
-                Y = 1,
-                Width = Dim.Fill() - 2,
-                Height = 1
-            };
-
-            _columnsList = new ListView()
-            {
-                X = 1,
-                Y = 3,
-                Width = Dim.Fill() - 2,
-                Height = Dim.Fill() - 1,
-                AllowsMarking = false,
-                AllowsMultipleSelection = false
-            };
-
-            // Create list of columns with checkboxes
-            RefreshColumnsList();
-
-            _shortcutsLabel = new Label()
-            {
-                Text = "Space: Toggle | Ctrl+A: All | Ctrl+N: None | Enter: OK | Esc: Cancel",
-                X = 1,
-                Y = Pos.Bottom(_columnsList),
-                Width = Dim.Fill() - 2,
-                Height = 1
-            };
-
-            Add(_instructionLabel, _columnsList, _shortcutsLabel);
-        }
-
-        private void SetupLayout()
-        {
-            _columnsList.SetFocus();
-        }
-
-        private void SetKeyboard()
-        {
-            KeyBindings.ReplaceCommands(Key.Enter, Command.Accept);
-            AddCommand(Command.Accept, () => { OnOkClicked(); return true; });
-            
-            KeyBindings.ReplaceCommands(Key.Esc, Command.Cancel);
-            AddCommand(Command.Cancel, () => { OnCancelClicked(); return true; });
-
-            _columnsList.KeyDown += (sender, key) =>
-            {
-                if (key == Key.Space)
-                {
-                    ToggleSelectedColumn();
-                    key.Handled = true;
-                }
-                else if (key.KeyCode == (Key.A.KeyCode | KeyCode.CtrlMask))
-                {
-                    SelectAllColumns();
-                    key.Handled = true;
-                }
-                else if (key.KeyCode == (Key.N.KeyCode | KeyCode.CtrlMask))
-                {
-                    SelectNoColumns();
-                    key.Handled = true;
-                }
-            };
-        }
-
-        private void ToggleSelectedColumn()
-        {
-            var selectedIndex = _columnsList.SelectedItem;
-            if (selectedIndex < 0 || selectedIndex >= _dataTable.Columns.Count)
-                return;
-
-            var columnName = _dataTable.Columns[selectedIndex].ColumnName;
-            
-            if (_selectedColumns.Contains(columnName))
-            {
-                _selectedColumns.Remove(columnName);
-            }
-            else
-            {
-                _selectedColumns.Add(columnName);
-            }
-
-            RefreshColumnsList();
-        }
-
-        private void SelectAllColumns()
-        {
-            _selectedColumns.Clear();
             foreach (DataColumn column in _dataTable.Columns)
             {
                 _selectedColumns.Add(column.ColumnName);
             }
-            RefreshColumnsList();
         }
 
-        private void SelectNoColumns()
-        {
-            _selectedColumns.Clear();
-            RefreshColumnsList();
-        }
+        Title = "Select Columns to Display";
+        Width = 60;
+        Height = Math.Min(30, _dataTable.Columns.Count + 8);
 
-        private void RefreshColumnsList()
+        InitializeComponents();
+        SetupLayout();
+        SetKeyboard();
+    }
+
+    private void InitializeComponents()
+    {
+        _instructionLabel = new Label()
         {
-            var currentSelected = _columnsList.SelectedItem;
-            var columnItems = new List<string>();
-            
-            foreach (DataColumn column in _dataTable.Columns)
+            Text = "Use Space to toggle column selection:",
+            X = 1,
+            Y = 1,
+            Width = Dim.Fill() - 2,
+            Height = 1
+        };
+
+        _columnsList = new ListView()
+        {
+            X = 1,
+            Y = 3,
+            Width = Dim.Fill() - 2,
+            Height = Dim.Fill() - 1,
+            AllowsMarking = false,
+            AllowsMultipleSelection = false
+        };
+
+        // Create list of columns with checkboxes
+        RefreshColumnsList();
+
+        _shortcutsLabel = new Label()
+        {
+            Text = "Space: Toggle | Ctrl+A: All | Ctrl+N: None | Enter: OK | Esc: Cancel",
+            X = 1,
+            Y = Pos.Bottom(_columnsList),
+            Width = Dim.Fill() - 2,
+            Height = 1
+        };
+
+        Add(_instructionLabel, _columnsList, _shortcutsLabel);
+    }
+
+    private void SetupLayout()
+    {
+        _columnsList.SetFocus();
+    }
+
+    private void SetKeyboard()
+    {
+        KeyBindings.ReplaceCommands(Key.Enter, Command.Accept);
+        AddCommand(Command.Accept, () => { OnOkClicked(); return true; });
+        
+        KeyBindings.ReplaceCommands(Key.Esc, Command.Cancel);
+        AddCommand(Command.Cancel, () => { OnCancelClicked(); return true; });
+
+        _columnsList.KeyDown += (sender, key) =>
+        {
+            if (key == Key.Space)
             {
-                var prefix = _selectedColumns.Contains(column.ColumnName) ? "[✓] " : "[ ] ";
-                columnItems.Add($"{prefix}{column.ColumnName}");
+                ToggleSelectedColumn();
+                key.Handled = true;
             }
-
-            _columnsList.SetSource(new ObservableCollection<string>(columnItems));
-            _columnsList.SelectedItem = Math.Max(0, Math.Min(currentSelected, columnItems.Count - 1));
-        }
-
-        private void OnOkClicked()
-        {
-            // Ensure at least one column is selected
-            if (_selectedColumns.Count == 0)
+            else if (key.KeyCode == (Key.A.KeyCode | KeyCode.CtrlMask))
             {
-                MessageBox.ErrorQuery("Validation Error", "At least one column must be selected.", "OK");
-                return;
+                SelectAllColumns();
+                key.Handled = true;
             }
+            else if (key.KeyCode == (Key.N.KeyCode | KeyCode.CtrlMask))
+            {
+                SelectNoColumns();
+                key.Handled = true;
+            }
+        };
+    }
 
-            Application.RequestStop();
-        }
+    private void ToggleSelectedColumn()
+    {
+        var selectedIndex = _columnsList.SelectedItem;
+        if (selectedIndex < 0 || selectedIndex >= _dataTable.Columns.Count)
+            return;
 
-        private void OnCancelClicked()
+        var columnName = _dataTable.Columns[selectedIndex].ColumnName;
+        
+        if (_selectedColumns.Contains(columnName))
         {
-            Application.RequestStop();
+            _selectedColumns.Remove(columnName);
         }
+        else
+        {
+            _selectedColumns.Add(columnName);
+        }
+
+        RefreshColumnsList();
+    }
+
+    private void SelectAllColumns()
+    {
+        _selectedColumns.Clear();
+        foreach (DataColumn column in _dataTable.Columns)
+        {
+            _selectedColumns.Add(column.ColumnName);
+        }
+        RefreshColumnsList();
+    }
+
+    private void SelectNoColumns()
+    {
+        _selectedColumns.Clear();
+        RefreshColumnsList();
+    }
+
+    private void RefreshColumnsList()
+    {
+        var currentSelected = _columnsList.SelectedItem;
+        var columnItems = new List<string>();
+        
+        foreach (DataColumn column in _dataTable.Columns)
+        {
+            var prefix = _selectedColumns.Contains(column.ColumnName) ? "[✓] " : "[ ] ";
+            columnItems.Add($"{prefix}{column.ColumnName}");
+        }
+
+        _columnsList.SetSource(new ObservableCollection<string>(columnItems));
+        _columnsList.SelectedItem = Math.Max(0, Math.Min(currentSelected, columnItems.Count - 1));
+    }
+
+    private void OnOkClicked()
+    {
+        // Ensure at least one column is selected
+        if (_selectedColumns.Count == 0)
+        {
+            MessageBox.ErrorQuery("Validation Error", "At least one column must be selected.", "OK");
+            return;
+        }
+
+        Application.RequestStop();
+    }
+
+    private void OnCancelClicked()
+    {
+        Application.RequestStop();
     }
 }

--- a/src/KustoTerminal.UI/Dialogs/ConnectionDialog.cs
+++ b/src/KustoTerminal.UI/Dialogs/ConnectionDialog.cs
@@ -7,206 +7,205 @@ using Terminal.Gui.ViewBase;
 using KustoTerminal.Core.Models;
 using Terminal.Gui.Input;
 
-namespace KustoTerminal.UI.Dialogs
+namespace KustoTerminal.UI.Dialogs;
+
+public class ConnectionDialog : Dialog
 {
-    public class ConnectionDialog : Dialog
+    private TextField _nameField;
+    private TextField _clusterUriField;
+    private TextField _databaseField;
+    private RadioGroup _authTypeGroup;
+    private Label _shortcutsLabel;
+    private readonly KustoConnection? _originalConnection;
+    
+    public KustoConnection? Result { get; private set; }
+
+    public ConnectionDialog(KustoConnection? connection = null)
     {
-        private TextField _nameField;
-        private TextField _clusterUriField;
-        private TextField _databaseField;
-        private RadioGroup _authTypeGroup;
-        private Label _shortcutsLabel;
-        private readonly KustoConnection? _originalConnection;
+        _originalConnection = connection;
+        Title = connection == null ? "Add Connection" : "Edit Connection";
+        Width = 60;
+        Height = 18;
+
+        InitializeComponents(connection);
+        SetupLayout();
+        SetKeyboard();
+    }
+
+    private void InitializeComponents(KustoConnection? connection)
+    {
+        // Name field
+        var nameLabel = new Label()
+        {
+            Text = "Name:",
+            X = 1,
+            Y = 1
+        };
         
-        public KustoConnection? Result { get; private set; }
-
-        public ConnectionDialog(KustoConnection? connection = null)
+        _nameField = new TextField()
         {
-            _originalConnection = connection;
-            Title = connection == null ? "Add Connection" : "Edit Connection";
-            Width = 60;
-            Height = 18;
+            Text = connection?.Name ?? "",
+            X = 15,
+            Y = 1,
+            Width = 40
+        };
 
-            InitializeComponents(connection);
-            SetupLayout();
-            SetKeyboard();
+        // Cluster URI field
+        var clusterLabel = new Label()
+        {
+            Text = "Cluster URI:",
+            X = 1,
+            Y = 3
+        };
+        
+        _clusterUriField = new TextField()
+        {
+            Text = connection?.ClusterUri ?? "",
+            X = 15,
+            Y = 3,
+            Width = 40
+        };
+
+        // Database field
+        var databaseLabel = new Label()
+        {
+            Text = "Database:",
+            X = 1,
+            Y = 5
+        };
+        
+        _databaseField = new TextField()
+        {
+            Text = connection?.Database ?? "",
+            X = 15,
+            Y = 5,
+            Width = 40
+        };
+
+        // Auth type selection
+        var authTypeLabel = new Label()
+        {
+            Text = "Auth Type:",
+            X = 1,
+            Y = 7
+        };
+
+        _authTypeGroup = new RadioGroup()
+        {
+            X = 15,
+            Y = 7,
+            Width = 40,
+            Height = 4,
+            RadioLabels = new string[] { "None (Unauthenticated)", "Azure CLI" }
+        };
+
+        // Set initial auth type selection
+        var authTypeIndex = connection?.AuthType switch
+        {
+            AuthenticationType.None => 0,
+            AuthenticationType.AzureCli => 1,
+            _ => 1 // Default to Azure CLI
+        };
+        _authTypeGroup.SelectedItem = authTypeIndex;
+
+        // Shortcuts label
+        _shortcutsLabel = new Label()
+        {
+            Text = "Enter: OK | Esc: Cancel",
+            X = 1,
+            Y = 12,
+            Width = Dim.Fill() - 2,
+            Height = 1,
+            // ColorScheme = ColorSchemeFactory.CreateShortcutLabel()
+        };
+
+        Add(nameLabel, _nameField, clusterLabel, _clusterUriField,
+            databaseLabel, _databaseField, authTypeLabel, _authTypeGroup, _shortcutsLabel);
+    }
+
+    private void SetupLayout()
+    {
+        // Focus on the first field
+        _nameField.SetFocus();
+    }
+
+    private void SetKeyboard()
+    {
+        KeyBindings.ReplaceCommands(Key.Enter, Command.Accept);
+        AddCommand(Command.Accept, () => { OnOkClicked(); return true; });
+        KeyBindings.ReplaceCommands(Key.Esc, Command.Cancel);
+        AddCommand(Command.Cancel, () => { OnCancelClicked(); return true; });
+    }
+
+    private void OnOkClicked()
+    {
+        // Validate input
+        var name = _nameField.Text?.ToString() ?? "";
+        var clusterUri = _clusterUriField.Text?.ToString() ?? "";
+        var database = _databaseField.Text?.ToString() ?? "";
+
+        if (string.IsNullOrWhiteSpace(clusterUri))
+        {
+            MessageBox.ErrorQuery("Validation Error", "Cluster URI is required.", "OK");
+            _clusterUriField.SetFocus();
+            return;
         }
 
-        private void InitializeComponents(KustoConnection? connection)
+        if (string.IsNullOrWhiteSpace(database))
         {
-            // Name field
-            var nameLabel = new Label()
-            {
-                Text = "Name:",
-                X = 1,
-                Y = 1
-            };
-            
-            _nameField = new TextField()
-            {
-                Text = connection?.Name ?? "",
-                X = 15,
-                Y = 1,
-                Width = 40
-            };
-
-            // Cluster URI field
-            var clusterLabel = new Label()
-            {
-                Text = "Cluster URI:",
-                X = 1,
-                Y = 3
-            };
-            
-            _clusterUriField = new TextField()
-            {
-                Text = connection?.ClusterUri ?? "",
-                X = 15,
-                Y = 3,
-                Width = 40
-            };
-
-            // Database field
-            var databaseLabel = new Label()
-            {
-                Text = "Database:",
-                X = 1,
-                Y = 5
-            };
-            
-            _databaseField = new TextField()
-            {
-                Text = connection?.Database ?? "",
-                X = 15,
-                Y = 5,
-                Width = 40
-            };
-
-            // Auth type selection
-            var authTypeLabel = new Label()
-            {
-                Text = "Auth Type:",
-                X = 1,
-                Y = 7
-            };
-
-            _authTypeGroup = new RadioGroup()
-            {
-                X = 15,
-                Y = 7,
-                Width = 40,
-                Height = 4,
-                RadioLabels = new string[] { "None (Unauthenticated)", "Azure CLI" }
-            };
-
-            // Set initial auth type selection
-            var authTypeIndex = connection?.AuthType switch
-            {
-                AuthenticationType.None => 0,
-                AuthenticationType.AzureCli => 1,
-                _ => 1 // Default to Azure CLI
-            };
-            _authTypeGroup.SelectedItem = authTypeIndex;
-
-            // Shortcuts label
-            _shortcutsLabel = new Label()
-            {
-                Text = "Enter: OK | Esc: Cancel",
-                X = 1,
-                Y = 12,
-                Width = Dim.Fill() - 2,
-                Height = 1,
-                // ColorScheme = ColorSchemeFactory.CreateShortcutLabel()
-            };
-
-            Add(nameLabel, _nameField, clusterLabel, _clusterUriField,
-                databaseLabel, _databaseField, authTypeLabel, _authTypeGroup, _shortcutsLabel);
+            MessageBox.ErrorQuery("Validation Error", "Database is required.", "OK");
+            _databaseField.SetFocus();
+            return;
         }
 
-        private void SetupLayout()
+        if (!Uri.TryCreate(clusterUri, UriKind.Absolute, out _))
         {
-            // Focus on the first field
-            _nameField.SetFocus();
+            MessageBox.ErrorQuery("Validation Error", "Invalid cluster URI format.", "OK");
+            _clusterUriField.SetFocus();
+            return;
         }
 
-        private void SetKeyboard()
+        // Get selected auth type
+        var selectedAuthType = _authTypeGroup.SelectedItem switch
         {
-            KeyBindings.ReplaceCommands(Key.Enter, Command.Accept);
-            AddCommand(Command.Accept, () => { OnOkClicked(); return true; });
-            KeyBindings.ReplaceCommands(Key.Esc, Command.Cancel);
-            AddCommand(Command.Cancel, () => { OnCancelClicked(); return true; });
-        }
+            0 => AuthenticationType.None,
+            1 => AuthenticationType.AzureCli,
+            _ => AuthenticationType.AzureCli
+        };
 
-        private void OnOkClicked()
+        // Create result - preserve original ID and timestamps for edits
+        if (_originalConnection != null)
         {
-            // Validate input
-            var name = _nameField.Text?.ToString() ?? "";
-            var clusterUri = _clusterUriField.Text?.ToString() ?? "";
-            var database = _databaseField.Text?.ToString() ?? "";
-
-            if (string.IsNullOrWhiteSpace(clusterUri))
+            // Editing existing connection - preserve ID and metadata
+            Result = new KustoConnection
             {
-                MessageBox.ErrorQuery("Validation Error", "Cluster URI is required.", "OK");
-                _clusterUriField.SetFocus();
-                return;
-            }
-
-            if (string.IsNullOrWhiteSpace(database))
-            {
-                MessageBox.ErrorQuery("Validation Error", "Database is required.", "OK");
-                _databaseField.SetFocus();
-                return;
-            }
-
-            if (!Uri.TryCreate(clusterUri, UriKind.Absolute, out _))
-            {
-                MessageBox.ErrorQuery("Validation Error", "Invalid cluster URI format.", "OK");
-                _clusterUriField.SetFocus();
-                return;
-            }
-
-            // Get selected auth type
-            var selectedAuthType = _authTypeGroup.SelectedItem switch
-            {
-                0 => AuthenticationType.None,
-                1 => AuthenticationType.AzureCli,
-                _ => AuthenticationType.AzureCli
+                Id = _originalConnection.Id,
+                Name = name,
+                ClusterUri = clusterUri,
+                Database = database,
+                AuthType = selectedAuthType,
+                CreatedAt = _originalConnection.CreatedAt,
+                LastUsed = _originalConnection.LastUsed
             };
-
-            // Create result - preserve original ID and timestamps for edits
-            if (_originalConnection != null)
-            {
-                // Editing existing connection - preserve ID and metadata
-                Result = new KustoConnection
-                {
-                    Id = _originalConnection.Id,
-                    Name = name,
-                    ClusterUri = clusterUri,
-                    Database = database,
-                    AuthType = selectedAuthType,
-                    CreatedAt = _originalConnection.CreatedAt,
-                    LastUsed = _originalConnection.LastUsed
-                };
-            }
-            else
-            {
-                // Creating new connection
-                Result = new KustoConnection
-                {
-                    Name = name,
-                    ClusterUri = clusterUri,
-                    Database = database,
-                    AuthType = selectedAuthType
-                };
-            }
-
-            Application.RequestStop();
         }
-
-        private void OnCancelClicked()
+        else
         {
-            Result = null;
-            Application.RequestStop();
+            // Creating new connection
+            Result = new KustoConnection
+            {
+                Name = name,
+                ClusterUri = clusterUri,
+                Database = database,
+                AuthType = selectedAuthType
+            };
         }
+
+        Application.RequestStop();
+    }
+
+    private void OnCancelClicked()
+    {
+        Result = null;
+        Application.RequestStop();
     }
 }

--- a/src/KustoTerminal.UI/Dialogs/JsonTreeViewDialog.cs
+++ b/src/KustoTerminal.UI/Dialogs/JsonTreeViewDialog.cs
@@ -9,402 +9,401 @@ using Terminal.Gui.ViewBase;
 using Terminal.Gui.Input;
 using Terminal.Gui.Drivers;
 
-namespace KustoTerminal.UI.Dialogs
+namespace KustoTerminal.UI.Dialogs;
+
+public class JsonTreeViewDialog : Dialog
 {
-    public class JsonTreeViewDialog : Dialog
+    private TreeView _treeView;
+    private Label _statusLabel;
+    private Label _shortcutsLabel;
+    private readonly string _jsonContent;
+    private readonly string _columnName;
+
+    public JsonTreeViewDialog(string columnName, string jsonContent)
     {
-        private TreeView _treeView;
-        private Label _statusLabel;
-        private Label _shortcutsLabel;
-        private readonly string _jsonContent;
-        private readonly string _columnName;
+        _columnName = columnName ?? "JSON Content";
+        _jsonContent = jsonContent ?? string.Empty;
 
-        public JsonTreeViewDialog(string columnName, string jsonContent)
+        Title = $"JSON Tree View: {_columnName}";
+        Width = 100;
+        Height = 30;
+        Modal = true;
+
+        InitializeComponents();
+        SetupLayout();
+        SetKeyboard();
+        LoadJsonData();
+    }
+
+    private void InitializeComponents()
+    {
+        _statusLabel = new Label()
         {
-            _columnName = columnName ?? "JSON Content";
-            _jsonContent = jsonContent ?? string.Empty;
+            Text = "Loading JSON...",
+            X = 1,
+            Y = 1,
+            Width = Dim.Fill() - 2,
+            Height = 1
+        };
 
-            Title = $"JSON Tree View: {_columnName}";
-            Width = 100;
-            Height = 30;
-            Modal = true;
-
-            InitializeComponents();
-            SetupLayout();
-            SetKeyboard();
-            LoadJsonData();
-        }
-
-        private void InitializeComponents()
+        _treeView = new TreeView()
         {
-            _statusLabel = new Label()
-            {
-                Text = "Loading JSON...",
-                X = 1,
-                Y = 1,
-                Width = Dim.Fill() - 2,
-                Height = 1
-            };
+            X = 1,
+            Y = 2,
+            Width = Dim.Fill() - 2,
+            Height = Dim.Fill() - 1,
+            CanFocus = true
+        };
 
-            _treeView = new TreeView()
-            {
-                X = 1,
-                Y = 2,
-                Width = Dim.Fill() - 2,
-                Height = Dim.Fill() - 1,
-                CanFocus = true
-            };
-
-            _shortcutsLabel = new Label()
-            {
-                Text = "Ctrl+E: Expand All | Ctrl+R: Collapse All",
-                X = 1,
-                Y = Pos.Bottom(_treeView),
-                Width = Dim.Fill() - 2,
-                Height = 1
-            };
-
-            Add(_statusLabel, _treeView, _shortcutsLabel);
-        }
-
-        private void SetupLayout()
+        _shortcutsLabel = new Label()
         {
-            _treeView.SetFocus();
-        }
+            Text = "Ctrl+E: Expand All | Ctrl+R: Collapse All",
+            X = 1,
+            Y = Pos.Bottom(_treeView),
+            Width = Dim.Fill() - 2,
+            Height = 1
+        };
 
-        private void SetKeyboard()
+        Add(_statusLabel, _treeView, _shortcutsLabel);
+    }
+
+    private void SetupLayout()
+    {
+        _treeView.SetFocus();
+    }
+
+    private void SetKeyboard()
+    {
+        KeyBindings.ReplaceCommands(Key.Esc, Command.Cancel);
+        AddCommand(Command.Cancel, () => { OnCloseClicked(); return true; });
+
+        _treeView.KeyDown += (sender, key) =>
         {
-            KeyBindings.ReplaceCommands(Key.Esc, Command.Cancel);
-            AddCommand(Command.Cancel, () => { OnCloseClicked(); return true; });
-
-            _treeView.KeyDown += (sender, key) =>
+            if (key.KeyCode == (KeyCode.CtrlMask | Key.C.KeyCode))
             {
-                if (key.KeyCode == (KeyCode.CtrlMask | Key.C.KeyCode))
-                {
-                    OnCopySelectedClicked();
-                    key.Handled = true;
-                }
-                else if (key.KeyCode == (KeyCode.CtrlMask | Key.E.KeyCode))
-                {
-                    OnExpandAllClicked();
-                    key.Handled = true;
-                }
-                else if (key.KeyCode == (KeyCode.CtrlMask | Key.R.KeyCode))
-                {
-                    OnCollapseAllClicked();
-                    key.Handled = true;
-                }
-                else if (key.KeyCode == Key.Enter.KeyCode)
-                {
-                    OnShowPropertyDetails();
-                    key.Handled = true;
-                }
-            };
-        }
-
-        private void LoadJsonData()
-        {
-            try
-            {
-                if (string.IsNullOrWhiteSpace(_jsonContent))
-                {
-                    _statusLabel.Text = "No JSON content to display";
-                    return;
-                }
-
-                // Parse and build tree
-                var jsonDocument = JsonDocument.Parse(_jsonContent);
-                var rootNode = BuildTreeFromJson("$", jsonDocument.RootElement, "$");
-                
-                _treeView.AddObject(rootNode);
-                _treeView.ExpandAll();
-                
-                _statusLabel.Text = $"JSON parsed successfully - {GetJsonElementCount(jsonDocument.RootElement)} elements";
+                OnCopySelectedClicked();
+                key.Handled = true;
             }
-            catch (JsonException ex)
+            else if (key.KeyCode == (KeyCode.CtrlMask | Key.E.KeyCode))
             {
-                _statusLabel.Text = $"Invalid JSON: {ex.Message}";
-                
-                // Create a simple text node with the raw content
-                var errorNode = new JsonTreeNode("Raw Content", _jsonContent, "$.RawContent", null);
-                _treeView.AddObject(errorNode);
+                OnExpandAllClicked();
+                key.Handled = true;
             }
-            catch (Exception ex)
+            else if (key.KeyCode == (KeyCode.CtrlMask | Key.R.KeyCode))
             {
-                _statusLabel.Text = $"Error loading JSON: {ex.Message}";
+                OnCollapseAllClicked();
+                key.Handled = true;
             }
-        }
+            else if (key.KeyCode == Key.Enter.KeyCode)
+            {
+                OnShowPropertyDetails();
+                key.Handled = true;
+            }
+        };
+    }
 
-        private JsonTreeNode BuildTreeFromJson(string name, JsonElement element, string jsonPath)
+    private void LoadJsonData()
+    {
+        try
         {
-            var node = new JsonTreeNode(name, GetJsonElementDisplayValue(element), jsonPath, element);
-
-            switch (element.ValueKind)
+            if (string.IsNullOrWhiteSpace(_jsonContent))
             {
-                case JsonValueKind.Object:
-                    foreach (var property in element.EnumerateObject())
-                    {
-                        var childPath = jsonPath == "$" ? $"$.{property.Name}" : $"{jsonPath}.{property.Name}";
-                        var childNode = BuildTreeFromJson(property.Name, property.Value, childPath);
-                        node.Children.Add(childNode);
-                    }
-                    break;
-
-                case JsonValueKind.Array:
-                    int index = 0;
-                    foreach (var item in element.EnumerateArray())
-                    {
-                        var childPath = $"{jsonPath}[{index}]";
-                        var childNode = BuildTreeFromJson($"[{index}]", item, childPath);
-                        node.Children.Add(childNode);
-                        index++;
-                    }
-                    break;
+                _statusLabel.Text = "No JSON content to display";
+                return;
             }
 
-            return node;
-        }
-
-        private string GetJsonElementDisplayValue(JsonElement element)
-        {
-            return element.ValueKind switch
-            {
-                JsonValueKind.String => $"\"{element.GetString()}\"",
-                JsonValueKind.Number => element.GetRawText(),
-                JsonValueKind.True => "true",
-                JsonValueKind.False => "false",
-                JsonValueKind.Null => "null",
-                JsonValueKind.Object => string.Empty,
-                JsonValueKind.Array => string.Empty,
-                _ => element.GetRawText()
-            };
-        }
-
-        private int GetJsonElementCount(JsonElement element)
-        {
-            int count = 1; // Count the element itself
-
-            switch (element.ValueKind)
-            {
-                case JsonValueKind.Object:
-                    foreach (var property in element.EnumerateObject())
-                    {
-                        count += GetJsonElementCount(property.Value);
-                    }
-                    break;
-
-                case JsonValueKind.Array:
-                    foreach (var item in element.EnumerateArray())
-                    {
-                        count += GetJsonElementCount(item);
-                    }
-                    break;
-            }
-
-            return count;
-        }
-
-        private void OnCopySelectedClicked()
-        {
-            try
-            {
-                var selectedObject = _treeView.SelectedObject;
-                if (selectedObject is JsonTreeNode node)
-                {
-                    Clipboard.Contents = node.Value;
-                    _statusLabel.Text = "Selected value copied to clipboard";
-                }
-            }
-            catch (Exception ex)
-            {
-                _statusLabel.Text = $"Copy failed: {ex.Message}";
-            }
-        }
-
-        private void OnExpandAllClicked()
-        {
-            try
-            {
-                _treeView.ExpandAll();
-                _statusLabel.Text = "All nodes expanded";
-            }
-            catch (Exception ex)
-            {
-                _statusLabel.Text = $"Expand all failed: {ex.Message}";
-            }
-        }
-
-        private void OnCollapseAllClicked()
-        {
-            try
-            {
-                CollapseAllRecursively();
-                _statusLabel.Text = "All nodes collapsed recursively";
-            }
-            catch (Exception ex)
-            {
-                _statusLabel.Text = $"Collapse all failed: {ex.Message}";
-            }
-        }
-
-        private void CollapseAllRecursively()
-        {
-            // Get all root objects and collapse them recursively
-            foreach (var rootObject in _treeView.Objects)
-            {
-                if (rootObject is JsonTreeNode rootNode)
-                {
-                    CollapseNodeRecursively(rootNode);
-                }
-            }
-        }
-
-        private void CollapseNodeRecursively(JsonTreeNode node)
-        {
-            // First collapse all children recursively
-            foreach (var child in node.Children.OfType<JsonTreeNode>())
-            {
-                CollapseNodeRecursively(child);
-            }
+            // Parse and build tree
+            var jsonDocument = JsonDocument.Parse(_jsonContent);
+            var rootNode = BuildTreeFromJson("$", jsonDocument.RootElement, "$");
             
-            // Then collapse this node if it has children
-            if (node.Children.Any())
-            {
-                _treeView.Collapse(node);
-            }
+            _treeView.AddObject(rootNode);
+            _treeView.ExpandAll();
+            
+            _statusLabel.Text = $"JSON parsed successfully - {GetJsonElementCount(jsonDocument.RootElement)} elements";
         }
-
-        private void OnShowPropertyDetails()
+        catch (JsonException ex)
         {
-            try
-            {
-                var selectedObject = _treeView.SelectedObject;
-                if (selectedObject is JsonTreeNode node)
-                {
-                    var detailsDialog = new PropertyDetailsDialog(node.Name, node.GetFullValue(), node.JsonPath);
-                    Application.Run(detailsDialog);
-                }
-            }
-            catch (Exception ex)
-            {
-                _statusLabel.Text = $"Show details failed: {ex.Message}";
-            }
+            _statusLabel.Text = $"Invalid JSON: {ex.Message}";
+            
+            // Create a simple text node with the raw content
+            var errorNode = new JsonTreeNode("Raw Content", _jsonContent, "$.RawContent", null);
+            _treeView.AddObject(errorNode);
         }
-
-        private void OnCloseClicked()
+        catch (Exception ex)
         {
-            Application.RequestStop();
+            _statusLabel.Text = $"Error loading JSON: {ex.Message}";
         }
     }
 
-    public class JsonTreeNode : TreeNode
+    private JsonTreeNode BuildTreeFromJson(string name, JsonElement element, string jsonPath)
     {
-        public string Name { get; set; }
-        public string Value { get; set; }
-        public string JsonPath { get; set; }
-        public JsonElement? OriginalElement { get; set; }
+        var node = new JsonTreeNode(name, GetJsonElementDisplayValue(element), jsonPath, element);
 
-        public JsonTreeNode(string name, string value, string jsonPath, JsonElement? originalElement)
-            : base(GetDisplayText(name, value))
+        switch (element.ValueKind)
         {
-            Name = name;
-            Value = value;
-            JsonPath = jsonPath;
-            OriginalElement = originalElement;
-        }
-
-        private static string GetDisplayText(string name, string value)
-        {
-            return $"{name}: {value}";
-        }
-
-        public string GetFullValue()
-        {
-            if (OriginalElement.HasValue)
-            {
-                var element = OriginalElement.Value;
-                if (element.ValueKind == JsonValueKind.Object || element.ValueKind == JsonValueKind.Array)
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
                 {
-                    // For objects and arrays, return formatted JSON
-                    return JsonSerializer.Serialize(element, new JsonSerializerOptions
-                    {
-                        WriteIndented = true
-                    });
+                    var childPath = jsonPath == "$" ? $"$.{property.Name}" : $"{jsonPath}.{property.Name}";
+                    var childNode = BuildTreeFromJson(property.Name, property.Value, childPath);
+                    node.Children.Add(childNode);
                 }
+                break;
+
+            case JsonValueKind.Array:
+                int index = 0;
+                foreach (var item in element.EnumerateArray())
+                {
+                    var childPath = $"{jsonPath}[{index}]";
+                    var childNode = BuildTreeFromJson($"[{index}]", item, childPath);
+                    node.Children.Add(childNode);
+                    index++;
+                }
+                break;
+        }
+
+        return node;
+    }
+
+    private string GetJsonElementDisplayValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => $"\"{element.GetString()}\"",
+            JsonValueKind.Number => element.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Null => "null",
+            JsonValueKind.Object => string.Empty,
+            JsonValueKind.Array => string.Empty,
+            _ => element.GetRawText()
+        };
+    }
+
+    private int GetJsonElementCount(JsonElement element)
+    {
+        int count = 1; // Count the element itself
+
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    count += GetJsonElementCount(property.Value);
+                }
+                break;
+
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    count += GetJsonElementCount(item);
+                }
+                break;
+        }
+
+        return count;
+    }
+
+    private void OnCopySelectedClicked()
+    {
+        try
+        {
+            var selectedObject = _treeView.SelectedObject;
+            if (selectedObject is JsonTreeNode node)
+            {
+                Clipboard.Contents = node.Value;
+                _statusLabel.Text = "Selected value copied to clipboard";
             }
-            
-            // For leaf nodes or when no element is available, return the original value
-            return Value ?? string.Empty;
+        }
+        catch (Exception ex)
+        {
+            _statusLabel.Text = $"Copy failed: {ex.Message}";
         }
     }
 
-    public class PropertyDetailsDialog : Dialog
+    private void OnExpandAllClicked()
     {
-        public PropertyDetailsDialog(string propertyName, string value, string jsonPath)
+        try
         {
-            Title = "Property Details";
-            Width = Dim.Percent(92);
-            Height = 20;
-            Modal = true;
-
-            var nameLabel = new Label()
-            {
-                Text = "Property Name:",
-                X = 1,
-                Y = 0,
-                Width = Dim.Fill() - 2,
-                Height = 1
-            };
-
-            var nameText = new TextView()
-            {
-                Text = propertyName,
-                X = 1,
-                Y = 1,
-                Width = Dim.Fill() - 2,
-                Height = 1,
-                ReadOnly = true
-            };
-
-            var pathLabel = new Label()
-            {
-                Text = "JSON Path:",
-                X = 1,
-                Y = 2,
-                Width = Dim.Fill() - 2,
-                Height = 1
-            };
-
-            var pathText = new TextView()
-            {
-                Text = jsonPath,
-                X = 1,
-                Y = 3,
-                Width = Dim.Fill() - 2,
-                Height = 1,
-                ReadOnly = true
-            };
-
-            var valueLabel = new Label()
-            {
-                Text = "Value:",
-                X = 1,
-                Y = 4,
-                Width = Dim.Fill() - 2,
-                Height = 1
-            };
-
-            var valueText = new TextView()
-            {
-                Text = value,
-                X = 1,
-                Y = 5,
-                Width = Dim.Fill() - 2,
-                Height = 10,
-                ReadOnly = true,
-            };
-
-            Add(nameLabel, nameText,pathLabel, pathText, valueLabel, valueText);
+            _treeView.ExpandAll();
+            _statusLabel.Text = "All nodes expanded";
         }
+        catch (Exception ex)
+        {
+            _statusLabel.Text = $"Expand all failed: {ex.Message}";
+        }
+    }
+
+    private void OnCollapseAllClicked()
+    {
+        try
+        {
+            CollapseAllRecursively();
+            _statusLabel.Text = "All nodes collapsed recursively";
+        }
+        catch (Exception ex)
+        {
+            _statusLabel.Text = $"Collapse all failed: {ex.Message}";
+        }
+    }
+
+    private void CollapseAllRecursively()
+    {
+        // Get all root objects and collapse them recursively
+        foreach (var rootObject in _treeView.Objects)
+        {
+            if (rootObject is JsonTreeNode rootNode)
+            {
+                CollapseNodeRecursively(rootNode);
+            }
+        }
+    }
+
+    private void CollapseNodeRecursively(JsonTreeNode node)
+    {
+        // First collapse all children recursively
+        foreach (var child in node.Children.OfType<JsonTreeNode>())
+        {
+            CollapseNodeRecursively(child);
+        }
+        
+        // Then collapse this node if it has children
+        if (node.Children.Any())
+        {
+            _treeView.Collapse(node);
+        }
+    }
+
+    private void OnShowPropertyDetails()
+    {
+        try
+        {
+            var selectedObject = _treeView.SelectedObject;
+            if (selectedObject is JsonTreeNode node)
+            {
+                var detailsDialog = new PropertyDetailsDialog(node.Name, node.GetFullValue(), node.JsonPath);
+                Application.Run(detailsDialog);
+            }
+        }
+        catch (Exception ex)
+        {
+            _statusLabel.Text = $"Show details failed: {ex.Message}";
+        }
+    }
+
+    private void OnCloseClicked()
+    {
+        Application.RequestStop();
+    }
+}
+
+public class JsonTreeNode : TreeNode
+{
+    public string Name { get; set; }
+    public string Value { get; set; }
+    public string JsonPath { get; set; }
+    public JsonElement? OriginalElement { get; set; }
+
+    public JsonTreeNode(string name, string value, string jsonPath, JsonElement? originalElement)
+        : base(GetDisplayText(name, value))
+    {
+        Name = name;
+        Value = value;
+        JsonPath = jsonPath;
+        OriginalElement = originalElement;
+    }
+
+    private static string GetDisplayText(string name, string value)
+    {
+        return $"{name}: {value}";
+    }
+
+    public string GetFullValue()
+    {
+        if (OriginalElement.HasValue)
+        {
+            var element = OriginalElement.Value;
+            if (element.ValueKind == JsonValueKind.Object || element.ValueKind == JsonValueKind.Array)
+            {
+                // For objects and arrays, return formatted JSON
+                return JsonSerializer.Serialize(element, new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                });
+            }
+        }
+        
+        // For leaf nodes or when no element is available, return the original value
+        return Value ?? string.Empty;
+    }
+}
+
+public class PropertyDetailsDialog : Dialog
+{
+    public PropertyDetailsDialog(string propertyName, string value, string jsonPath)
+    {
+        Title = "Property Details";
+        Width = Dim.Percent(92);
+        Height = 20;
+        Modal = true;
+
+        var nameLabel = new Label()
+        {
+            Text = "Property Name:",
+            X = 1,
+            Y = 0,
+            Width = Dim.Fill() - 2,
+            Height = 1
+        };
+
+        var nameText = new TextView()
+        {
+            Text = propertyName,
+            X = 1,
+            Y = 1,
+            Width = Dim.Fill() - 2,
+            Height = 1,
+            ReadOnly = true
+        };
+
+        var pathLabel = new Label()
+        {
+            Text = "JSON Path:",
+            X = 1,
+            Y = 2,
+            Width = Dim.Fill() - 2,
+            Height = 1
+        };
+
+        var pathText = new TextView()
+        {
+            Text = jsonPath,
+            X = 1,
+            Y = 3,
+            Width = Dim.Fill() - 2,
+            Height = 1,
+            ReadOnly = true
+        };
+
+        var valueLabel = new Label()
+        {
+            Text = "Value:",
+            X = 1,
+            Y = 4,
+            Width = Dim.Fill() - 2,
+            Height = 1
+        };
+
+        var valueText = new TextView()
+        {
+            Text = value,
+            X = 1,
+            Y = 5,
+            Width = Dim.Fill() - 2,
+            Height = 10,
+            ReadOnly = true,
+        };
+
+        Add(nameLabel, nameText,pathLabel, pathText, valueLabel, valueText);
     }
 }

--- a/src/KustoTerminal.UI/MainWindow.cs
+++ b/src/KustoTerminal.UI/MainWindow.cs
@@ -13,511 +13,510 @@ using KustoTerminal.UI.Dialogs;
 using Terminal.Gui.Input;
 using Terminal.Gui.Drivers;
 
-namespace KustoTerminal.UI
+namespace KustoTerminal.UI;
+
+public class MainWindow : Window
 {
-    public class MainWindow : Window
+    private readonly IConnectionManager _connectionManager;
+    private readonly IAuthenticationProvider _authProvider;
+    private readonly IUserSettingsManager _userSettingsManager;
+    
+    private ConnectionPane _connectionPane;
+    private QueryEditorPane _queryEditorPane;
+    private ResultsPane _resultsPane;        
+    private FrameView _leftFrame;
+    private FrameView _rightTopFrame;
+    private FrameView _rightBottomFrame;
+
+    // Query cancellation
+    private CancellationTokenSource? _queryCancellationTokenSource;
+    private Core.Services.KustoClient? _currentKustoClient;
+    
+    // Maximize state
+    private bool _isQueryEditorMaximized = false;
+    private bool _isResultsPaneMaximized = false;
+    private Dim _originalRightFrameHeight;
+    private Pos _originalBottomFrameY;
+    private Dim _originalBottomFrameHeight;
+
+    public MainWindow(IConnectionManager connectionManager, IUserSettingsManager userSettingsManager)
     {
-        private readonly IConnectionManager _connectionManager;
-        private readonly IAuthenticationProvider _authProvider;
-        private readonly IUserSettingsManager _userSettingsManager;
+        _connectionManager = connectionManager ?? throw new ArgumentNullException(nameof(connectionManager));
+        _userSettingsManager = userSettingsManager ?? throw new ArgumentNullException(nameof(userSettingsManager));
+
+        Title = "Kusto Terminal - (Ctrl+Q to quit)";
+        X = 0;
+        Y = 0; // Leave space for menu bar
+        Width = Dim.Fill();
+        Height = Dim.Fill() - 1; // Leave space for status bar
+
+        InitializeComponents();
+        SetupLayout();
+        SetKeyboard();
+    }
+
+    private void InitializeComponents()
+    {
+        // Create frames for layout
+        _leftFrame = new FrameView()
+        {
+            Title = "Connections",
+            X = 0,
+            Y = 0,
+            Width = 30,
+            Height = Dim.Fill(),
+            TabStop = TabBehavior.TabStop
+        };
+
+        _rightTopFrame = new FrameView()
+        {
+            Title = "Query Editor",
+            X = 31,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Percent(60),
+            TabStop = TabBehavior.TabStop
+        };
+
+        _rightBottomFrame = new FrameView()
+        {
+            Title = "Results",
+            X = 31,
+            Y = Pos.Bottom(_rightTopFrame),
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            TabStop = TabBehavior.TabStop
+        };
+
+        // Create panes
+        _connectionPane = new ConnectionPane(_connectionManager)
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+
+        _queryEditorPane = new QueryEditorPane(_userSettingsManager)
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+
+        _resultsPane = new ResultsPane()
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+
+        var _shortcutsLabel = new Label()
+        {
+            Text = "Ctrl+Q to quit",
+            X = 1,
+            Y = Pos.AnchorEnd(1),
+            Width = Dim.Fill(),
+            Height = 1
+        };
+    }
+
+    private void SetupLayout()
+    {
+        // Add frames to window
+        Add(_leftFrame, _rightTopFrame, _rightBottomFrame);
+
+        // Add panes to frames
+        _leftFrame.Add(_connectionPane);
+        _rightTopFrame.Add(_queryEditorPane);
+        _rightBottomFrame.Add(_resultsPane);
         
-        private ConnectionPane _connectionPane;
-        private QueryEditorPane _queryEditorPane;
-        private ResultsPane _resultsPane;        
-        private FrameView _leftFrame;
-        private FrameView _rightTopFrame;
-        private FrameView _rightBottomFrame;
+        // Set initial focus to connection pane
+        _connectionPane.SetFocus();
 
-        // Query cancellation
-        private CancellationTokenSource? _queryCancellationTokenSource;
-        private Core.Services.KustoClient? _currentKustoClient;
+        // Set up events
+        _connectionPane.ConnectionSelected += OnConnectionSelected;
+        _queryEditorPane.QueryExecuteRequested += OnQueryExecuteRequested;
+        _queryEditorPane.EscapePressed += OnQueryEditorEscapePressed;
+        _queryEditorPane.QueryCancelRequested += OnQueryCancelRequested;
+        _queryEditorPane.MaximizeToggleRequested += OnQueryEditorMaximizeToggleRequested;
+        _resultsPane.MaximizeToggleRequested += OnResultsPaneMaximizeToggleRequested;
         
-        // Maximize state
-        private bool _isQueryEditorMaximized = false;
-        private bool _isResultsPaneMaximized = false;
-        private Dim _originalRightFrameHeight;
-        private Pos _originalBottomFrameY;
-        private Dim _originalBottomFrameHeight;
+        // Store original dimensions for restore
+        _originalRightFrameHeight = _rightTopFrame.Height;
+        _originalBottomFrameY = _rightBottomFrame.Y;
+        _originalBottomFrameHeight = _rightBottomFrame.Height;
+        
+        // Load last query asynchronously
+        LoadLastQueryAsync();
+    }
 
-        public MainWindow(IConnectionManager connectionManager, IUserSettingsManager userSettingsManager)
+    private void SetKeyboard()
+    {
+        KeyDown += (o, key) =>
         {
-            _connectionManager = connectionManager ?? throw new ArgumentNullException(nameof(connectionManager));
-            _userSettingsManager = userSettingsManager ?? throw new ArgumentNullException(nameof(userSettingsManager));
-
-            Title = "Kusto Terminal - (Ctrl+Q to quit)";
-            X = 0;
-            Y = 0; // Leave space for menu bar
-            Width = Dim.Fill();
-            Height = Dim.Fill() - 1; // Leave space for status bar
-
-            InitializeComponents();
-            SetupLayout();
-            SetKeyboard();
-        }
-
-        private void InitializeComponents()
-        {
-            // Create frames for layout
-            _leftFrame = new FrameView()
+            if (key.KeyCode == (KeyCode.CtrlMask | Key.Q.KeyCode)
+            || key.KeyCode == (KeyCode.CtrlMask | Key.C.KeyCode))
             {
-                Title = "Connections",
-                X = 0,
-                Y = 0,
-                Width = 30,
-                Height = Dim.Fill(),
-                TabStop = TabBehavior.TabStop
-            };
-
-            _rightTopFrame = new FrameView()
+                Application.Shutdown();
+                key.Handled = true;
+            }
+            else if (key == Key.F12)
             {
-                Title = "Query Editor",
-                X = 31,
-                Y = 0,
-                Width = Dim.Fill(),
-                Height = Dim.Percent(60),
-                TabStop = TabBehavior.TabStop
-            };
-
-            _rightBottomFrame = new FrameView()
+                ToggleMaximizeBasedOnFocus();
+                key.Handled = true;
+            }
+            else if (key == Key.Esc)
             {
-                Title = "Results",
-                X = 31,
-                Y = Pos.Bottom(_rightTopFrame),
-                Width = Dim.Fill(),
-                Height = Dim.Fill(),
-                TabStop = TabBehavior.TabStop
-            };
-
-            // Create panes
-            _connectionPane = new ConnectionPane(_connectionManager)
+                key.Handled = true;
+            }
+            else if (key == (KeyCode.AltMask | Key.CursorRight.KeyCode))
             {
-                X = 0,
-                Y = 0,
-                Width = Dim.Fill(),
-                Height = Dim.Fill()
-            };
-
-            _queryEditorPane = new QueryEditorPane(_userSettingsManager)
-            {
-                X = 0,
-                Y = 0,
-                Width = Dim.Fill(),
-                Height = Dim.Fill()
-            };
-
-            _resultsPane = new ResultsPane()
-            {
-                X = 0,
-                Y = 0,
-                Width = Dim.Fill(),
-                Height = Dim.Fill()
-            };
-
-            var _shortcutsLabel = new Label()
-            {
-                Text = "Ctrl+Q to quit",
-                X = 1,
-                Y = Pos.AnchorEnd(1),
-                Width = Dim.Fill(),
-                Height = 1
-            };
-        }
-
-        private void SetupLayout()
-        {
-            // Add frames to window
-            Add(_leftFrame, _rightTopFrame, _rightBottomFrame);
-
-            // Add panes to frames
-            _leftFrame.Add(_connectionPane);
-            _rightTopFrame.Add(_queryEditorPane);
-            _rightBottomFrame.Add(_resultsPane);
-            
-            // Set initial focus to connection pane
-            _connectionPane.SetFocus();
-
-            // Set up events
-            _connectionPane.ConnectionSelected += OnConnectionSelected;
-            _queryEditorPane.QueryExecuteRequested += OnQueryExecuteRequested;
-            _queryEditorPane.EscapePressed += OnQueryEditorEscapePressed;
-            _queryEditorPane.QueryCancelRequested += OnQueryCancelRequested;
-            _queryEditorPane.MaximizeToggleRequested += OnQueryEditorMaximizeToggleRequested;
-            _resultsPane.MaximizeToggleRequested += OnResultsPaneMaximizeToggleRequested;
-            
-            // Store original dimensions for restore
-            _originalRightFrameHeight = _rightTopFrame.Height;
-            _originalBottomFrameY = _rightBottomFrame.Y;
-            _originalBottomFrameHeight = _rightBottomFrame.Height;
-            
-            // Load last query asynchronously
-            LoadLastQueryAsync();
-        }
-
-        private void SetKeyboard()
-        {
-            KeyDown += (o, key) =>
-            {
-                if (key.KeyCode == (KeyCode.CtrlMask | Key.Q.KeyCode)
-                || key.KeyCode == (KeyCode.CtrlMask | Key.C.KeyCode))
+                if (_leftFrame.HasFocus)
                 {
-                    Application.Shutdown();
+                    _rightTopFrame.SetFocus();
                     key.Handled = true;
                 }
-                else if (key == Key.F12)
+            }
+            else if (key == (KeyCode.AltMask | Key.CursorLeft.KeyCode))
+            {
+                if (_rightBottomFrame.HasFocus || _rightTopFrame.HasFocus)
                 {
-                    ToggleMaximizeBasedOnFocus();
+                    _leftFrame.SetFocus();
+                }
+            }
+            else if (key == (KeyCode.AltMask | Key.CursorDown.KeyCode))
+            {
+                if (_rightTopFrame.HasFocus)
+                {
+                    _rightBottomFrame.SetFocus();
                     key.Handled = true;
                 }
-                else if (key == Key.Esc)
+            }
+            else if (key == (KeyCode.AltMask | Key.CursorUp.KeyCode))
+            {
+                if (_rightBottomFrame.HasFocus)
                 {
+                    _rightTopFrame.SetFocus();
                     key.Handled = true;
                 }
-                else if (key == (KeyCode.AltMask | Key.CursorRight.KeyCode))
-                {
-                    if (_leftFrame.HasFocus)
-                    {
-                        _rightTopFrame.SetFocus();
-                        key.Handled = true;
-                    }
-                }
-                else if (key == (KeyCode.AltMask | Key.CursorLeft.KeyCode))
-                {
-                    if (_rightBottomFrame.HasFocus || _rightTopFrame.HasFocus)
-                    {
-                        _leftFrame.SetFocus();
-                    }
-                }
-                else if (key == (KeyCode.AltMask | Key.CursorDown.KeyCode))
-                {
-                    if (_rightTopFrame.HasFocus)
-                    {
-                        _rightBottomFrame.SetFocus();
-                        key.Handled = true;
-                    }
-                }
-                else if (key == (KeyCode.AltMask | Key.CursorUp.KeyCode))
-                {
-                    if (_rightBottomFrame.HasFocus)
-                    {
-                        _rightTopFrame.SetFocus();
-                        key.Handled = true;
-                    }
-                }
-            };
-        }
-
-        private void OnConnectionSelected(object? sender, KustoConnection connection)
-        {
-            _queryEditorPane.SetConnection(connection);
-            _queryEditorPane.FocusEditor();
-        }
-
-        private async void OnQueryExecuteRequested(object? sender, string query)
-        {
-            await ExecuteQueryAsync(query);
-        }
-
-        private void OnQueryEditorEscapePressed(object? sender, EventArgs e)
-        {
-            _resultsPane.SetFocus();
-        }
-
-        private void OnQueryCancelRequested(object? sender, EventArgs e)
-        {
-            // Cancel the current query if one is running
-            if (_queryCancellationTokenSource != null && !_queryCancellationTokenSource.Token.IsCancellationRequested)
-            {
-                // First cancel the token to stop any local processing
-                _queryCancellationTokenSource.Cancel();
-                
-                // Immediately set executing to false to allow new queries
-                Application.Invoke(() => _queryEditorPane.SetExecuting(false));
-                
-                // Then try to cancel on the server side using the Kusto client (fire-and-forget)
-                if (_currentKustoClient != null)
-                {
-                    var clientToCancel = _currentKustoClient;
-                    _ = Task.Run(async () =>
-                    {
-                        try
-                        {
-                            await clientToCancel.CancelCurrentQueryAsync();
-                        }
-                        catch (Exception ex)
-                        {
-                            // Log but don't throw - cancellation errors shouldn't crash the UI
-                            Console.WriteLine($"Warning: Server-side cancellation failed: {ex.Message}");
-                        }
-                    });
-                }
             }
-        }
+        };
+    }
 
-        private void OnQueryEditorMaximizeToggleRequested(object? sender, EventArgs e)
-        {
-            ToggleQueryEditorMaximize();
-        }
+    private void OnConnectionSelected(object? sender, KustoConnection connection)
+    {
+        _queryEditorPane.SetConnection(connection);
+        _queryEditorPane.FocusEditor();
+    }
 
-        private void OnResultsPaneMaximizeToggleRequested(object? sender, EventArgs e)
-        {
-            ToggleResultsPaneMaximize();
-        }
+    private async void OnQueryExecuteRequested(object? sender, string query)
+    {
+        await ExecuteQueryAsync(query);
+    }
 
-        private void ToggleMaximizeBasedOnFocus()
-        {
-            // Determine which pane has focus and toggle accordingly
-            if (_resultsPane.HasFocus)
-            {
-                ToggleResultsPaneMaximize();
-            }
-            else
-            {
-                // Default to query editor if focus is unclear
-                ToggleQueryEditorMaximize();
-            }
-        }
+    private void OnQueryEditorEscapePressed(object? sender, EventArgs e)
+    {
+        _resultsPane.SetFocus();
+    }
 
-        private void ToggleQueryEditorMaximize()
+    private void OnQueryCancelRequested(object? sender, EventArgs e)
+    {
+        // Cancel the current query if one is running
+        if (_queryCancellationTokenSource != null && !_queryCancellationTokenSource.Token.IsCancellationRequested)
         {
-            if (_isQueryEditorMaximized)
+            // First cancel the token to stop any local processing
+            _queryCancellationTokenSource.Cancel();
+            
+            // Immediately set executing to false to allow new queries
+            Application.Invoke(() => _queryEditorPane.SetExecuting(false));
+            
+            // Then try to cancel on the server side using the Kusto client (fire-and-forget)
+            if (_currentKustoClient != null)
             {
-                RestoreNormalLayout();
-            }
-            else
-            {
-                MaximizeQueryEditor();
-            }
-        }
-
-        private void ToggleResultsPaneMaximize()
-        {
-            if (_isResultsPaneMaximized)
-            {
-                RestoreNormalLayout();
-            }
-            else
-            {
-                MaximizeResultsPane();
-            }
-        }
-
-        private void MaximizeQueryEditor()
-        {
-            // First restore any existing maximized state
-            if (_isResultsPaneMaximized)
-            {
-                _isResultsPaneMaximized = false;
-            }
-            
-            _isQueryEditorMaximized = true;
-            
-            // Hide connection and results frames
-            _leftFrame.Visible = false;
-            _rightBottomFrame.Visible = false;
-            
-            // Expand query editor frame to fill entire window
-            _rightTopFrame.X = 0;
-            _rightTopFrame.Width = Dim.Fill();
-            _rightTopFrame.Height = Dim.Fill();
-            _rightTopFrame.Title = "Query Editor (Maximized - F12 to restore)";
-            
-            // Ensure query editor gets focus
-            _queryEditorPane.FocusEditor();
-            
-            // Trigger layout refresh
-            SetNeedsLayout();
-        }
-
-        private void MaximizeResultsPane()
-        {
-            // First restore any existing maximized state
-            if (_isQueryEditorMaximized)
-            {
-                _isQueryEditorMaximized = false;
-            }
-            
-            _isResultsPaneMaximized = true;
-            
-            // Hide connection and query editor frames
-            _leftFrame.Visible = false;
-            _rightTopFrame.Visible = false;
-            
-            // Expand results frame to fill entire window
-            _rightBottomFrame.X = 0;
-            _rightBottomFrame.Y = 0;
-            _rightBottomFrame.Width = Dim.Fill();
-            _rightBottomFrame.Height = Dim.Fill();
-            _rightBottomFrame.Title = "Results (Maximized - F12 to restore)";
-            
-            // Ensure results pane gets focus
-            _resultsPane.SetFocus();
-            
-            // Trigger layout refresh
-            SetNeedsLayout();
-        }
-
-        private void RestoreNormalLayout()
-        {
-            _isQueryEditorMaximized = false;
-            _isResultsPaneMaximized = false;
-            
-            // Show all frames
-            _leftFrame.Visible = true;
-            _rightTopFrame.Visible = true;
-            _rightBottomFrame.Visible = true;
-            
-            // Restore original dimensions for query editor frame
-            _rightTopFrame.X = 31;
-            _rightTopFrame.Width = Dim.Fill();
-            _rightTopFrame.Height = _originalRightFrameHeight;
-            _rightTopFrame.Title = "Query Editor";
-            
-            // Restore original dimensions for results frame
-            _rightBottomFrame.X = 31;
-            _rightBottomFrame.Y = _originalBottomFrameY;
-            _rightBottomFrame.Width = Dim.Fill();
-            _rightBottomFrame.Height = _originalBottomFrameHeight;
-            _rightBottomFrame.Title = "Results";
-            
-            // Trigger layout refresh
-            SetNeedsLayout();
-        }
-
-        private async Task ExecuteQueryAsync(string query)
-        {
-            // If there's an existing query, cancel it but don't wait
-            if (_queryCancellationTokenSource != null && !_queryCancellationTokenSource.Token.IsCancellationRequested)
-            {
-                var oldCancellationSource = _queryCancellationTokenSource;
-                var oldClient = _currentKustoClient;
-                
-                // Cancel the old query
-                oldCancellationSource.Cancel();
-                
-                // Clean up the old resources in the background
+                var clientToCancel = _currentKustoClient;
                 _ = Task.Run(async () =>
                 {
                     try
                     {
-                        if (oldClient != null)
-                        {
-                            await oldClient.CancelCurrentQueryAsync();
-                            oldClient.Dispose();
-                        }
+                        await clientToCancel.CancelCurrentQueryAsync();
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"Warning: Failed to clean up old query: {ex.Message}");
-                    }
-                    finally
-                    {
-                        oldCancellationSource?.Dispose();
+                        // Log but don't throw - cancellation errors shouldn't crash the UI
+                        Console.WriteLine($"Warning: Server-side cancellation failed: {ex.Message}");
                     }
                 });
             }
-            
-            // Create new cancellation token source for this query
-            _queryCancellationTokenSource = new CancellationTokenSource();
-            var cancellationToken = _queryCancellationTokenSource.Token;
-            
-            try
-            {
-                var connection = _connectionPane.GetSelectedConnection();
-                if (connection == null)
-                {
-                    Application.Invoke(() => _queryEditorPane.SetExecuting(false));
-                    return;
-                }
-
-                // Create progress handler
-                var progress = new Progress<string>(message =>
-                {
-                    Application.Invoke(() =>
-                    {
-                        _queryEditorPane.UpdateProgressMessage(message);
-                    });
-                });
-                var authProvider = AuthenticationProviderFactory.CreateProvider(connection.AuthType);
-                _currentKustoClient = new Core.Services.KustoClient(connection, authProvider);
-                var result = await _currentKustoClient.ExecuteQueryAsync(query, cancellationToken, progress);
-                _currentKustoClient.Dispose();
-                _currentKustoClient = null;
-                
-                Application.Invoke(() =>
-                {
-                    _queryEditorPane.SetExecuting(false);
-                    _resultsPane.DisplayResult(result);
-                });
-            }
-            catch (OperationCanceledException)
-            {
-                Application.Invoke(() =>
-                {
-                    _queryEditorPane.SetExecuting(false);
-                });
-            }
-            catch (Exception ex)
-            {
-                Application.Invoke(() =>
-                {
-                    _queryEditorPane.SetExecuting(false);
-                });
-            }
-            finally
-            {
-                // Clean up the cancellation token source and client
-                if (_queryCancellationTokenSource != null)
-                {
-                    _queryCancellationTokenSource.Dispose();
-                    _queryCancellationTokenSource = null;
-                }
-                
-                if (_currentKustoClient != null)
-                {
-                    _currentKustoClient.Dispose();
-                    _currentKustoClient = null;
-                }
-            }
         }
+    }
 
+    private void OnQueryEditorMaximizeToggleRequested(object? sender, EventArgs e)
+    {
+        ToggleQueryEditorMaximize();
+    }
 
-        public static IDisposable Run(IConnectionManager connectionManager, IUserSettingsManager userSettingsManager)
+    private void OnResultsPaneMaximizeToggleRequested(object? sender, EventArgs e)
+    {
+        ToggleResultsPaneMaximize();
+    }
+
+    private void ToggleMaximizeBasedOnFocus()
+    {
+        // Determine which pane has focus and toggle accordingly
+        if (_resultsPane.HasFocus)
         {
-            var mainWindow = new MainWindow(connectionManager, userSettingsManager);
-            Application.Run(mainWindow);
-            return mainWindow;
+            ToggleResultsPaneMaximize();
+        }
+        else
+        {
+            // Default to query editor if focus is unclear
+            ToggleQueryEditorMaximize();
+        }
+    }
+
+    private void ToggleQueryEditorMaximize()
+    {
+        if (_isQueryEditorMaximized)
+        {
+            RestoreNormalLayout();
+        }
+        else
+        {
+            MaximizeQueryEditor();
+        }
+    }
+
+    private void ToggleResultsPaneMaximize()
+    {
+        if (_isResultsPaneMaximized)
+        {
+            RestoreNormalLayout();
+        }
+        else
+        {
+            MaximizeResultsPane();
+        }
+    }
+
+    private void MaximizeQueryEditor()
+    {
+        // First restore any existing maximized state
+        if (_isResultsPaneMaximized)
+        {
+            _isResultsPaneMaximized = false;
         }
         
-        private async void LoadLastQueryAsync()
+        _isQueryEditorMaximized = true;
+        
+        // Hide connection and results frames
+        _leftFrame.Visible = false;
+        _rightBottomFrame.Visible = false;
+        
+        // Expand query editor frame to fill entire window
+        _rightTopFrame.X = 0;
+        _rightTopFrame.Width = Dim.Fill();
+        _rightTopFrame.Height = Dim.Fill();
+        _rightTopFrame.Title = "Query Editor (Maximized - F12 to restore)";
+        
+        // Ensure query editor gets focus
+        _queryEditorPane.FocusEditor();
+        
+        // Trigger layout refresh
+        SetNeedsLayout();
+    }
+
+    private void MaximizeResultsPane()
+    {
+        // First restore any existing maximized state
+        if (_isQueryEditorMaximized)
         {
-            try
-            {
-                // Load the last query when the window is set up
-                _queryEditorPane.LoadLastQueryAsync();
-            }
-            catch (Exception ex)
-            {
-                // Silently fail - don't crash the app if we can't load the last query
-                Console.WriteLine($"Warning: Failed to load last query: {ex.Message}");
-            }
+            _isQueryEditorMaximized = false;
         }
         
-        protected override void Dispose(bool disposing)
+        _isResultsPaneMaximized = true;
+        
+        // Hide connection and query editor frames
+        _leftFrame.Visible = false;
+        _rightTopFrame.Visible = false;
+        
+        // Expand results frame to fill entire window
+        _rightBottomFrame.X = 0;
+        _rightBottomFrame.Y = 0;
+        _rightBottomFrame.Width = Dim.Fill();
+        _rightBottomFrame.Height = Dim.Fill();
+        _rightBottomFrame.Title = "Results (Maximized - F12 to restore)";
+        
+        // Ensure results pane gets focus
+        _resultsPane.SetFocus();
+        
+        // Trigger layout refresh
+        SetNeedsLayout();
+    }
+
+    private void RestoreNormalLayout()
+    {
+        _isQueryEditorMaximized = false;
+        _isResultsPaneMaximized = false;
+        
+        // Show all frames
+        _leftFrame.Visible = true;
+        _rightTopFrame.Visible = true;
+        _rightBottomFrame.Visible = true;
+        
+        // Restore original dimensions for query editor frame
+        _rightTopFrame.X = 31;
+        _rightTopFrame.Width = Dim.Fill();
+        _rightTopFrame.Height = _originalRightFrameHeight;
+        _rightTopFrame.Title = "Query Editor";
+        
+        // Restore original dimensions for results frame
+        _rightBottomFrame.X = 31;
+        _rightBottomFrame.Y = _originalBottomFrameY;
+        _rightBottomFrame.Width = Dim.Fill();
+        _rightBottomFrame.Height = _originalBottomFrameHeight;
+        _rightBottomFrame.Title = "Results";
+        
+        // Trigger layout refresh
+        SetNeedsLayout();
+    }
+
+    private async Task ExecuteQueryAsync(string query)
+    {
+        // If there's an existing query, cancel it but don't wait
+        if (_queryCancellationTokenSource != null && !_queryCancellationTokenSource.Token.IsCancellationRequested)
         {
-            if (disposing)
+            var oldCancellationSource = _queryCancellationTokenSource;
+            var oldClient = _currentKustoClient;
+            
+            // Cancel the old query
+            oldCancellationSource.Cancel();
+            
+            // Clean up the old resources in the background
+            _ = Task.Run(async () =>
             {
-                // Save current query before disposing
                 try
                 {
-                    _queryEditorPane?.SaveCurrentQueryAsync();
+                    if (oldClient != null)
+                    {
+                        await oldClient.CancelCurrentQueryAsync();
+                        oldClient.Dispose();
+                    }
                 }
                 catch (Exception ex)
                 {
-                    // Silently fail - don't crash during shutdown
-                    Console.WriteLine($"Warning: Failed to save query during shutdown: {ex.Message}");
+                    Console.WriteLine($"Warning: Failed to clean up old query: {ex.Message}");
                 }
-            }
-            base.Dispose(disposing);
+                finally
+                {
+                    oldCancellationSource?.Dispose();
+                }
+            });
         }
+        
+        // Create new cancellation token source for this query
+        _queryCancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = _queryCancellationTokenSource.Token;
+        
+        try
+        {
+            var connection = _connectionPane.GetSelectedConnection();
+            if (connection == null)
+            {
+                Application.Invoke(() => _queryEditorPane.SetExecuting(false));
+                return;
+            }
+
+            // Create progress handler
+            var progress = new Progress<string>(message =>
+            {
+                Application.Invoke(() =>
+                {
+                    _queryEditorPane.UpdateProgressMessage(message);
+                });
+            });
+            var authProvider = AuthenticationProviderFactory.CreateProvider(connection.AuthType);
+            _currentKustoClient = new Core.Services.KustoClient(connection, authProvider);
+            var result = await _currentKustoClient.ExecuteQueryAsync(query, cancellationToken, progress);
+            _currentKustoClient.Dispose();
+            _currentKustoClient = null;
+            
+            Application.Invoke(() =>
+            {
+                _queryEditorPane.SetExecuting(false);
+                _resultsPane.DisplayResult(result);
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            Application.Invoke(() =>
+            {
+                _queryEditorPane.SetExecuting(false);
+            });
+        }
+        catch (Exception ex)
+        {
+            Application.Invoke(() =>
+            {
+                _queryEditorPane.SetExecuting(false);
+            });
+        }
+        finally
+        {
+            // Clean up the cancellation token source and client
+            if (_queryCancellationTokenSource != null)
+            {
+                _queryCancellationTokenSource.Dispose();
+                _queryCancellationTokenSource = null;
+            }
+            
+            if (_currentKustoClient != null)
+            {
+                _currentKustoClient.Dispose();
+                _currentKustoClient = null;
+            }
+        }
+    }
+
+
+    public static IDisposable Run(IConnectionManager connectionManager, IUserSettingsManager userSettingsManager)
+    {
+        var mainWindow = new MainWindow(connectionManager, userSettingsManager);
+        Application.Run(mainWindow);
+        return mainWindow;
+    }
+    
+    private async void LoadLastQueryAsync()
+    {
+        try
+        {
+            // Load the last query when the window is set up
+            _queryEditorPane.LoadLastQueryAsync();
+        }
+        catch (Exception ex)
+        {
+            // Silently fail - don't crash the app if we can't load the last query
+            Console.WriteLine($"Warning: Failed to load last query: {ex.Message}");
+        }
+    }
+    
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Save current query before disposing
+            try
+            {
+                _queryEditorPane?.SaveCurrentQueryAsync();
+            }
+            catch (Exception ex)
+            {
+                // Silently fail - don't crash during shutdown
+                Console.WriteLine($"Warning: Failed to save query during shutdown: {ex.Message}");
+            }
+        }
+        base.Dispose(disposing);
     }
 }

--- a/src/KustoTerminal.UI/Models/ClusterTreeNode.cs
+++ b/src/KustoTerminal.UI/Models/ClusterTreeNode.cs
@@ -8,116 +8,115 @@ using KustoTerminal.Core.Interfaces;
 using KustoTerminal.Core.Services;
 using Terminal.Gui.Views;
 
-namespace KustoTerminal.UI.Models
+namespace KustoTerminal.UI.Models;
+
+public class ClusterTreeNode : TreeNode
 {
-    public class ClusterTreeNode : TreeNode
+    public KustoConnection Connection { get; }
+    private readonly IKustoClient _kustoClient;
+    private readonly IConnectionManager _connectionManager;
+    private bool _isLoadingDatabases = false;
+
+    public ClusterTreeNode(KustoConnection connection, IKustoClient kustoClient, IConnectionManager connectionManager)
+        : base(GetDisplayText(connection))
     {
-        public KustoConnection Connection { get; }
-        private readonly IKustoClient _kustoClient;
-        private readonly IConnectionManager _connectionManager;
-        private bool _isLoadingDatabases = false;
+        Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        _kustoClient = kustoClient ?? throw new ArgumentNullException(nameof(kustoClient));
+        _connectionManager = connectionManager ?? throw new ArgumentNullException(nameof(connectionManager));
+        
+        // Load persisted databases if available
+        LoadPersistedDatabases();
+    }
 
-        public ClusterTreeNode(KustoConnection connection, IKustoClient kustoClient, IConnectionManager connectionManager)
-            : base(GetDisplayText(connection))
-        {
-            Connection = connection ?? throw new ArgumentNullException(nameof(connection));
-            _kustoClient = kustoClient ?? throw new ArgumentNullException(nameof(kustoClient));
-            _connectionManager = connectionManager ?? throw new ArgumentNullException(nameof(connectionManager));
-            
-            // Load persisted databases if available
-            LoadPersistedDatabases();
-        }
+    private static string GetDisplayText(KustoConnection connection)
+    {
+        var prefix = connection.IsDefault ? "* " : "  ";
+        return $"{prefix}{connection.DisplayName}";
+    }
 
-        private static string GetDisplayText(KustoConnection connection)
-        {
-            var prefix = connection.IsDefault ? "* " : "  ";
-            return $"{prefix}{connection.DisplayName}";
-        }
+    private string GetDisplayText()
+    {
+        var prefix = Connection.IsDefault ? "* " : "  ";
+        var suffix = _isLoadingDatabases ? " (Loading)" : "";
+        return $"{prefix}{Connection.DisplayName}{suffix}";
+    }
 
-        private string GetDisplayText()
-        {
-            var prefix = Connection.IsDefault ? "* " : "  ";
-            var suffix = _isLoadingDatabases ? " (Loading)" : "";
-            return $"{prefix}{Connection.DisplayName}{suffix}";
-        }
+    public void SetLoadingState(bool isLoading)
+    {
+        _isLoadingDatabases = isLoading;
+        Text = GetDisplayText();
+    }
 
-        public void SetLoadingState(bool isLoading)
-        {
-            _isLoadingDatabases = isLoading;
-            Text = GetDisplayText();
-        }
-
-        private void LoadPersistedDatabases()
-        {
-            // Load from persisted databases if available
-            if (Connection.Databases != null && Connection.Databases.Any())
-            {
-                Children.Clear();
-                foreach (var database in Connection.Databases)
-                {
-                    Children.Add(new DatabaseTreeNode(database, Connection));
-                }
-            }
-        }
-
-        public async Task LoadDatabasesAsync(bool forceRefresh = false)
-        {
-            // If we have persisted databases and not forcing refresh, use them
-            if (!forceRefresh && Connection.Databases != null && Connection.Databases.Any())
-            {
-                LoadPersistedDatabases();
-                return;
-            }
-
-            SetLoadingState(true);
-
-            try
-            {
-                var databases = await _kustoClient.GetDatabasesAsync();
-                
-                // Update the connection with fresh database list and persist it
-                await _connectionManager.RefreshDatabasesAsync(Connection.Id, _kustoClient);
-                
-                // Clear existing children and add database nodes
-                Children.Clear();
-                foreach (var database in databases)
-                {
-                    Children.Add(new DatabaseTreeNode(database, Connection));
-                }
-            }
-            catch (Exception ex)
-            {
-                // Add an error node if databases couldn't be loaded
-                Children.Clear();
-                Children.Add(new TreeNode($"Error loading databases: {ex.Message}"));
-            }
-            finally
-            {
-                SetLoadingState(false);
-            }
-        }
-
-        public async Task RefreshDatabasesAsync()
-        {
-            await LoadDatabasesAsync(forceRefresh: true);
-        }
-
-        public void RefreshDatabases()
+    private void LoadPersistedDatabases()
+    {
+        // Load from persisted databases if available
+        if (Connection.Databases != null && Connection.Databases.Any())
         {
             Children.Clear();
+            foreach (var database in Connection.Databases)
+            {
+                Children.Add(new DatabaseTreeNode(database, Connection));
+            }
         }
     }
 
-    public class DatabaseTreeNode : TreeNode
+    public async Task LoadDatabasesAsync(bool forceRefresh = false)
     {
-        public string DatabaseName { get; }
-        public KustoConnection ParentConnection { get; }
-
-        public DatabaseTreeNode(string databaseName, KustoConnection parentConnection)
-            : base(databaseName)
+        // If we have persisted databases and not forcing refresh, use them
+        if (!forceRefresh && Connection.Databases != null && Connection.Databases.Any())
         {
-            DatabaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));
-            ParentConnection = parentConnection ?? throw new ArgumentNullException(nameof(parentConnection));
+            LoadPersistedDatabases();
+            return;
         }
+
+        SetLoadingState(true);
+
+        try
+        {
+            var databases = await _kustoClient.GetDatabasesAsync();
+            
+            // Update the connection with fresh database list and persist it
+            await _connectionManager.RefreshDatabasesAsync(Connection.Id, _kustoClient);
+            
+            // Clear existing children and add database nodes
+            Children.Clear();
+            foreach (var database in databases)
+            {
+                Children.Add(new DatabaseTreeNode(database, Connection));
+            }
+        }
+        catch (Exception ex)
+        {
+            // Add an error node if databases couldn't be loaded
+            Children.Clear();
+            Children.Add(new TreeNode($"Error loading databases: {ex.Message}"));
+        }
+        finally
+        {
+            SetLoadingState(false);
+        }
+    }
+
+    public async Task RefreshDatabasesAsync()
+    {
+        await LoadDatabasesAsync(forceRefresh: true);
+    }
+
+    public void RefreshDatabases()
+    {
+        Children.Clear();
+    }
+}
+
+public class DatabaseTreeNode : TreeNode
+{
+    public string DatabaseName { get; }
+    public KustoConnection ParentConnection { get; }
+
+    public DatabaseTreeNode(string databaseName, KustoConnection parentConnection)
+        : base(databaseName)
+    {
+        DatabaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));
+        ParentConnection = parentConnection ?? throw new ArgumentNullException(nameof(parentConnection));
     }
 }

--- a/src/KustoTerminal.UI/Panes/BasePane.cs
+++ b/src/KustoTerminal.UI/Panes/BasePane.cs
@@ -5,10 +5,9 @@ using Terminal.Gui.Views;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Drawing;
 
-namespace KustoTerminal.UI.Panes
+namespace KustoTerminal.UI.Panes;
+
+public abstract class BasePane : View
 {
-    public abstract class BasePane : View
-    {
-        public event EventHandler<bool>? FocusChanged;
-    }
+    public event EventHandler<bool>? FocusChanged;
 }

--- a/src/KustoTerminal.UI/Panes/ConnectionPane.cs
+++ b/src/KustoTerminal.UI/Panes/ConnectionPane.cs
@@ -17,296 +17,295 @@ using Terminal.Gui.Drivers;
 using Kusto.Cloud.Platform.Utils;
 using Terminal.Gui.Drawing;
 
-namespace KustoTerminal.UI.Panes
+namespace KustoTerminal.UI.Panes;
+
+public class ConnectionPane : View
 {
-    public class ConnectionPane : View
+    private readonly IConnectionManager _connectionManager;
+    private TreeView _connectionsTree;
+    private Label[] _shortcutsLabels;
+
+    
+    private KustoConnection[] _connections = Array.Empty<KustoConnection>();
+    private KustoConnection? _selectedConnection;
+    private readonly Dictionary<string, IKustoClient> _kustoClients = new();
+
+    public event EventHandler<KustoConnection>? ConnectionSelected;
+
+    public ConnectionPane(IConnectionManager connectionManager)
     {
-        private readonly IConnectionManager _connectionManager;
-        private TreeView _connectionsTree;
-        private Label[] _shortcutsLabels;
+        _connectionManager = connectionManager ?? throw new ArgumentNullException(nameof(connectionManager));
 
-        
-        private KustoConnection[] _connections = Array.Empty<KustoConnection>();
-        private KustoConnection? _selectedConnection;
-        private readonly Dictionary<string, IKustoClient> _kustoClients = new();
+        InitializeComponents();
+        SetupLayout();
+        SetKeyboard();
+        LoadConnections();
+        CanFocus = true;
+    }
 
-        public event EventHandler<KustoConnection>? ConnectionSelected;
-
-        public ConnectionPane(IConnectionManager connectionManager)
+    private void InitializeComponents()
+    {
+        _connectionsTree = new TreeView()
         {
-            _connectionManager = connectionManager ?? throw new ArgumentNullException(nameof(connectionManager));
-
-            InitializeComponents();
-            SetupLayout();
-            SetKeyboard();
-            LoadConnections();
-            CanFocus = true;
-        }
-
-        private void InitializeComponents()
-        {
-            _connectionsTree = new TreeView()
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            Style = new TreeStyle()
             {
+                ExpandableSymbol = Glyphs.RightArrow,
+                CollapseableSymbol = Glyphs.DownArrow,
+            }
+        };
+
+        _shortcutsLabels = new[]{
+            new Label()
+            {
+                Text = "Ctrl+N: New",
                 X = 0,
-                Y = 0,
+                Y = Pos.Bottom(_connectionsTree) - 4,
                 Width = Dim.Fill(),
-                Height = Dim.Fill(),
-                Style = new TreeStyle()
-                {
-                    ExpandableSymbol = Glyphs.RightArrow,
-                    CollapseableSymbol = Glyphs.DownArrow,
-                }
-            };
-
-            _shortcutsLabels = new[]{
-                new Label()
-                {
-                    Text = "Ctrl+N: New",
-                    X = 0,
-                    Y = Pos.Bottom(_connectionsTree) - 4,
-                    Width = Dim.Fill(),
-                    Height = 1,
-                    SchemeName = "TopLevel"
-                },
-                new Label()
-                {
-                    Text = "Ctrl+E: Edit",
-                    X = 0,
-                    Y = Pos.Bottom(_connectionsTree) - 3,
-                    Width = Dim.Fill(),
-                    Height = 1,
-                    SchemeName = "TopLevel"
-                },
-                new Label()
-                {
-                    Text = "Del: Delete",
-                    X = 0,
-                    Y = Pos.Bottom(_connectionsTree) - 2,
-                    Width = Dim.Fill(),
-                    Height = 1,
-                    SchemeName = "TopLevel"
-                },
-                new Label()
-                {
-                    Text = "Space: Expand DBs",
-                    X = 0,
-                    Y = Pos.Bottom(_connectionsTree) - 1,
-                    Width = Dim.Fill(),
-                    Height = 1,
-                    SchemeName = "TopLevel"
-                }
-            };
-
-            // Set up event handlers
-            _connectionsTree.SelectionChanged += OnTreeSelectionChanged;
-            _connectionsTree.ObjectActivated += OnTreeObjectActivated;
-        }
-
-        private void SetKeyboard()
-        {
-            _connectionsTree.KeyDown += (o, key) =>
+                Height = 1,
+                SchemeName = "TopLevel"
+            },
+            new Label()
             {
-                if (key.KeyCode == (Key.N.KeyCode | KeyCode.CtrlMask))
-                {
-                    OnAddClicked();
-                    key.Handled = true;
-                }
-                else if (key.KeyCode == (Key.E.KeyCode | KeyCode.CtrlMask))
-                {
-                    OnEditClicked();
-                    key.Handled = true;
-                }
-                else if (key == Key.DeleteChar)
-                {
-                    OnDeleteClicked();
-                    key.Handled = true;
-                }
-                else if (key == Key.Space)
-                {
-                    OnExpandDatabases();
-                    key.Handled = true;
-                }
-            };
-        }
-
-        private void SetupLayout()
-        {
-            Add(_connectionsTree);
-            _shortcutsLabels.ToList().ForEach(label => Add(label));
-        }
-
-        private async void LoadConnections()
-        {
-            try
+                Text = "Ctrl+E: Edit",
+                X = 0,
+                Y = Pos.Bottom(_connectionsTree) - 3,
+                Width = Dim.Fill(),
+                Height = 1,
+                SchemeName = "TopLevel"
+            },
+            new Label()
             {
-                var connections = await _connectionManager.GetConnectionsAsync();
-                _connections = connections.ToArray();
-                
-                // Clear existing tree
-                _connectionsTree.ClearObjects();
-                
-                // Add cluster nodes to tree
-                foreach (var connection in _connections)
-                {
-                    var clusterNode = new ClusterTreeNode(connection, GetKustoClient(connection), _connectionManager);
-                    _connectionsTree.AddObject(clusterNode);
-                }
-
-                if (_connections.Length > 0)
-                {
-                    _selectedConnection = _connections[0];
-                }
+                Text = "Del: Delete",
+                X = 0,
+                Y = Pos.Bottom(_connectionsTree) - 2,
+                Width = Dim.Fill(),
+                Height = 1,
+                SchemeName = "TopLevel"
+            },
+            new Label()
+            {
+                Text = "Space: Expand DBs",
+                X = 0,
+                Y = Pos.Bottom(_connectionsTree) - 1,
+                Width = Dim.Fill(),
+                Height = 1,
+                SchemeName = "TopLevel"
             }
-            catch (Exception ex)
+        };
+
+        // Set up event handlers
+        _connectionsTree.SelectionChanged += OnTreeSelectionChanged;
+        _connectionsTree.ObjectActivated += OnTreeObjectActivated;
+    }
+
+    private void SetKeyboard()
+    {
+        _connectionsTree.KeyDown += (o, key) =>
+        {
+            if (key.KeyCode == (Key.N.KeyCode | KeyCode.CtrlMask))
             {
-                MessageBox.ErrorQuery("Error", $"Failed to load connections: {ex.Message}", "OK");
+                OnAddClicked();
+                key.Handled = true;
             }
-        }
+            else if (key.KeyCode == (Key.E.KeyCode | KeyCode.CtrlMask))
+            {
+                OnEditClicked();
+                key.Handled = true;
+            }
+            else if (key == Key.DeleteChar)
+            {
+                OnDeleteClicked();
+                key.Handled = true;
+            }
+            else if (key == Key.Space)
+            {
+                OnExpandDatabases();
+                key.Handled = true;
+            }
+        };
+    }
 
-        public async void RefreshConnections()
-        {
-            LoadConnections();
-        }
+    private void SetupLayout()
+    {
+        Add(_connectionsTree);
+        _shortcutsLabels.ToList().ForEach(label => Add(label));
+    }
 
-        private void OnTreeSelectionChanged(object? sender, SelectionChangedEventArgs<ITreeNode> args)
+    private async void LoadConnections()
+    {
+        try
         {
-            var selectedNode = _connectionsTree.SelectedObject;
+            var connections = await _connectionManager.GetConnectionsAsync();
+            _connections = connections.ToArray();
             
-            if (selectedNode is ClusterTreeNode clusterNode)
-            {
-                _selectedConnection = clusterNode.Connection;
-            }
-            else if (selectedNode is DatabaseTreeNode dbNode)
-            {
-                _selectedConnection = dbNode.ParentConnection;
-            }
-            else
-            {
-                _selectedConnection = null;
-            }
-        }
-
-        private void OnExpandDatabases()
-        {
-            var selectedNode = _connectionsTree.SelectedObject;
+            // Clear existing tree
+            _connectionsTree.ClearObjects();
             
-            if (selectedNode is ClusterTreeNode clusterNode)
+            // Add cluster nodes to tree
+            foreach (var connection in _connections)
             {
-                // Load and expand databases for the selected cluster
-                Task.Run(async () => {
-                    // Refresh immediately to show loading state
-                    Application.Invoke(() => _connectionsTree.RefreshObject(clusterNode));
-                    
-                    await clusterNode.LoadDatabasesAsync();
-                    
-                    // Refresh again after loading is complete
-                    Application.Invoke(() =>
-                    {
-                        _connectionsTree.RefreshObject(clusterNode);
-                        _connectionsTree.Expand(clusterNode);
-                    });
-                });
+                var clusterNode = new ClusterTreeNode(connection, GetKustoClient(connection), _connectionManager);
+                _connectionsTree.AddObject(clusterNode);
+            }
+
+            if (_connections.Length > 0)
+            {
+                _selectedConnection = _connections[0];
             }
         }
-
-        private void OnTreeObjectActivated(object? sender, ObjectActivatedEventArgs<ITreeNode> args)
+        catch (Exception ex)
         {
-            if (args.ActivatedObject is ClusterTreeNode clusterNode)
-            {
-                OnConnectClicked();
-            }
-            else if (args.ActivatedObject is DatabaseTreeNode dbNode)
-            {
-                // When a database is activated, update the connection's database and connect
-                _selectedConnection = new KustoConnection
+            MessageBox.ErrorQuery("Error", $"Failed to load connections: {ex.Message}", "OK");
+        }
+    }
+
+    public async void RefreshConnections()
+    {
+        LoadConnections();
+    }
+
+    private void OnTreeSelectionChanged(object? sender, SelectionChangedEventArgs<ITreeNode> args)
+    {
+        var selectedNode = _connectionsTree.SelectedObject;
+        
+        if (selectedNode is ClusterTreeNode clusterNode)
+        {
+            _selectedConnection = clusterNode.Connection;
+        }
+        else if (selectedNode is DatabaseTreeNode dbNode)
+        {
+            _selectedConnection = dbNode.ParentConnection;
+        }
+        else
+        {
+            _selectedConnection = null;
+        }
+    }
+
+    private void OnExpandDatabases()
+    {
+        var selectedNode = _connectionsTree.SelectedObject;
+        
+        if (selectedNode is ClusterTreeNode clusterNode)
+        {
+            // Load and expand databases for the selected cluster
+            Task.Run(async () => {
+                // Refresh immediately to show loading state
+                Application.Invoke(() => _connectionsTree.RefreshObject(clusterNode));
+                
+                await clusterNode.LoadDatabasesAsync();
+                
+                // Refresh again after loading is complete
+                Application.Invoke(() =>
                 {
-                    Id = dbNode.ParentConnection.Id,
-                    Name = dbNode.ParentConnection.Name,
-                    ClusterUri = dbNode.ParentConnection.ClusterUri,
-                    Database = dbNode.DatabaseName,
-                    Databases = dbNode.ParentConnection.Databases,
-                    AuthType = dbNode.ParentConnection.AuthType,
-                    CreatedAt = dbNode.ParentConnection.CreatedAt,
-                    LastUsed = DateTime.UtcNow,
-                    IsDefault = dbNode.ParentConnection.IsDefault
-                };
-                OnConnectClicked();
-            }
-        }
-
-        private void OnAddClicked()
-        {
-            var dialog = new ConnectionDialog();
-            Application.Run(dialog);
-
-            if (dialog.Result != null)
-            {
-                Task.Run(async () =>
-                {
-                    await _connectionManager.AddConnectionAsync(dialog.Result);
-                    Application.Invoke(() => RefreshConnections());
+                    _connectionsTree.RefreshObject(clusterNode);
+                    _connectionsTree.Expand(clusterNode);
                 });
-            }
+            });
         }
+    }
 
-        private void OnEditClicked()
+    private void OnTreeObjectActivated(object? sender, ObjectActivatedEventArgs<ITreeNode> args)
+    {
+        if (args.ActivatedObject is ClusterTreeNode clusterNode)
         {
-            if (_selectedConnection == null) return;
-
-            var dialog = new ConnectionDialog(_selectedConnection);
-            Application.Run(dialog);
-
-            if (dialog.Result != null)
+            OnConnectClicked();
+        }
+        else if (args.ActivatedObject is DatabaseTreeNode dbNode)
+        {
+            // When a database is activated, update the connection's database and connect
+            _selectedConnection = new KustoConnection
             {
-                Task.Run(async () =>
-                {
-                    await _connectionManager.UpdateConnectionAsync(dialog.Result);
-                    Application.Invoke(() => RefreshConnections());
-                });
-            }
+                Id = dbNode.ParentConnection.Id,
+                Name = dbNode.ParentConnection.Name,
+                ClusterUri = dbNode.ParentConnection.ClusterUri,
+                Database = dbNode.DatabaseName,
+                Databases = dbNode.ParentConnection.Databases,
+                AuthType = dbNode.ParentConnection.AuthType,
+                CreatedAt = dbNode.ParentConnection.CreatedAt,
+                LastUsed = DateTime.UtcNow,
+                IsDefault = dbNode.ParentConnection.IsDefault
+            };
+            OnConnectClicked();
         }
+    }
 
-        private void OnDeleteClicked()
+    private void OnAddClicked()
+    {
+        var dialog = new ConnectionDialog();
+        Application.Run(dialog);
+
+        if (dialog.Result != null)
         {
-            if (_selectedConnection == null) return;
-
-            var result = MessageBox.Query("Confirm Delete",
-                $"Are you sure you want to delete connection '{_selectedConnection.DisplayName}'?",
-                "Yes", "No");
-
-            if (result == 0) // Yes
+            Task.Run(async () =>
             {
-                Task.Run(async () =>
-                {
-                    await _connectionManager.DeleteConnectionAsync(_selectedConnection.Id);
-                    Application.Invoke(() => RefreshConnections());
-                });
-            }
+                await _connectionManager.AddConnectionAsync(dialog.Result);
+                Application.Invoke(() => RefreshConnections());
+            });
         }
+    }
 
-        private void OnConnectClicked()
+    private void OnEditClicked()
+    {
+        if (_selectedConnection == null) return;
+
+        var dialog = new ConnectionDialog(_selectedConnection);
+        Application.Run(dialog);
+
+        if (dialog.Result != null)
         {
-            if (_selectedConnection != null)
+            Task.Run(async () =>
             {
-                ConnectionSelected?.Invoke(this, _selectedConnection);
-            }
+                await _connectionManager.UpdateConnectionAsync(dialog.Result);
+                Application.Invoke(() => RefreshConnections());
+            });
         }
+    }
 
-        public KustoConnection? GetSelectedConnection()
-        {
-            return _selectedConnection;
-        }
+    private void OnDeleteClicked()
+    {
+        if (_selectedConnection == null) return;
 
-        private IKustoClient GetKustoClient(KustoConnection connection)
+        var result = MessageBox.Query("Confirm Delete",
+            $"Are you sure you want to delete connection '{_selectedConnection.DisplayName}'?",
+            "Yes", "No");
+
+        if (result == 0) // Yes
         {
-            if (!_kustoClients.TryGetValue(connection.Id, out var client))
+            Task.Run(async () =>
             {
-                var authProvider = AuthenticationProviderFactory.CreateProvider(connection.AuthType);
-                client = new KustoClient(connection, authProvider);
-                _kustoClients[connection.Id] = client;
-            }
-
-            return client;
+                await _connectionManager.DeleteConnectionAsync(_selectedConnection.Id);
+                Application.Invoke(() => RefreshConnections());
+            });
         }
+    }
+
+    private void OnConnectClicked()
+    {
+        if (_selectedConnection != null)
+        {
+            ConnectionSelected?.Invoke(this, _selectedConnection);
+        }
+    }
+
+    public KustoConnection? GetSelectedConnection()
+    {
+        return _selectedConnection;
+    }
+
+    private IKustoClient GetKustoClient(KustoConnection connection)
+    {
+        if (!_kustoClients.TryGetValue(connection.Id, out var client))
+        {
+            var authProvider = AuthenticationProviderFactory.CreateProvider(connection.AuthType);
+            client = new KustoClient(connection, authProvider);
+            _kustoClients[connection.Id] = client;
+        }
+
+        return client;
     }
 }

--- a/src/KustoTerminal.UI/Panes/QueryEditorPane.cs
+++ b/src/KustoTerminal.UI/Panes/QueryEditorPane.cs
@@ -9,325 +9,324 @@ using KustoTerminal.Core.Interfaces;
 using Terminal.Gui.Input;
 using Terminal.Gui.Drivers;
 
-namespace KustoTerminal.UI.Panes
+namespace KustoTerminal.UI.Panes;
+
+public class QueryEditorPane : BasePane
 {
-    public class QueryEditorPane : BasePane
+    private TextView _queryTextView;
+    private Label _connectionLabel;
+    private Label _progressLabel;
+    private Label _shortcutsLabel;
+    private Label _temporaryMessageLabel;
+    
+    private bool _isExecuting = false;
+    private System.Threading.Timer? _temporaryMessageTimer;
+    private readonly IUserSettingsManager? _userSettingsManager;
+
+    public event EventHandler<string>? QueryExecuteRequested;
+    public event EventHandler? EscapePressed;
+    public event EventHandler? QueryCancelRequested;
+    public event EventHandler? MaximizeToggleRequested;
+
+    public QueryEditorPane(IUserSettingsManager? userSettingsManager = null)
     {
-        private TextView _queryTextView;
-        private Label _connectionLabel;
-        private Label _progressLabel;
-        private Label _shortcutsLabel;
-        private Label _temporaryMessageLabel;
+        _userSettingsManager = userSettingsManager;
+        InitializeComponents();
+        SetupLayout();
+        SetKeyboard();
+        CanFocus = true;
+    }
+
+    private void InitializeComponents()
+    {
+        _connectionLabel = new Label()
+        {
+            Text = "No connection",
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = 1
+        };
+
+        _queryTextView = new TextView()
+        {
+            X = 0,
+            Y = 1,
+            Width = Dim.Fill(),
+            Height = Dim.Fill() - 1,
+            Text = "",
+        };
+
+        _shortcutsLabel = new Label()
+        {
+            Text = "F5: Execute | F12: Maximize/Restore",
+            X = 0,
+            Y = Pos.Bottom(_queryTextView),
+            Width = Dim.Fill(),
+            Height = 1,
+            SchemeName = "TopLevel"
+        };
+
+        _progressLabel = new Label()
+        {
+            X = 0,
+            Y = Pos.Bottom(_shortcutsLabel) - 1,
+            Width = Dim.Fill(),
+            Height = 1,
+            Visible = false
+        };
+
+        _temporaryMessageLabel = new Label()
+        {
+            X = 0,
+            Y = Pos.Bottom(_progressLabel) - 1,
+            Width = Dim.Fill(),
+            Height = 1,
+            Visible = false
+        };
+    }
+
+    private void SetKeyboard()
+    {
+        _queryTextView.KeyBindings.ReplaceCommands(KeyCode.CtrlMask | Key.V.KeyCode, Command.Paste);
+        _queryTextView.KeyBindings.ReplaceCommands(KeyCode.CtrlMask | Key.C.KeyCode, Command.Copy);
+
+        _queryTextView.KeyDown += (sender, key) =>
+        {
+            if (key == Key.F5)
+            {
+                OnExecuteClicked();
+            }
+            else if (key == Key.F12)
+            {
+                MaximizeToggleRequested?.Invoke(this, EventArgs.Empty);
+                key.Handled = true;
+            }
+            else if (key == Key.Esc)
+            {
+                if (_isExecuting)
+                {
+                    QueryCancelRequested?.Invoke(this, EventArgs.Empty);
+                }
+                else
+                {
+                    EscapePressed?.Invoke(this, EventArgs.Empty);
+                }
+                    
+                key.Handled = true;
+            }
+        };
+    }
+
+    private void SetupLayout()
+    {
+        Add(_connectionLabel, _queryTextView, _shortcutsLabel, _progressLabel, _temporaryMessageLabel);
+    }
+
+    private void OnExecuteClicked()
+    {
+        var query = GetCurrentQuery();
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            SetExecuting(true);
+            QueryExecuteRequested?.Invoke(this, query);
+        }
+        else
+        {
+            MessageBox.ErrorQuery("Error", "Please enter a query to execute.", "OK");
+        }
+    }
+
+    public string GetCurrentQuery()
+    {
+        var fullText = _queryTextView.Text?.ToString() ?? "";
+        if (string.IsNullOrEmpty(fullText))
+            return "";
+
+        // Get cursor position (Point with X=column, Y=row)
+        var cursorPos = _queryTextView.CursorPosition;
         
-        private bool _isExecuting = false;
-        private System.Threading.Timer? _temporaryMessageTimer;
-        private readonly IUserSettingsManager? _userSettingsManager;
-
-        public event EventHandler<string>? QueryExecuteRequested;
-        public event EventHandler? EscapePressed;
-        public event EventHandler? QueryCancelRequested;
-        public event EventHandler? MaximizeToggleRequested;
-
-        public QueryEditorPane(IUserSettingsManager? userSettingsManager = null)
+        // Split text into lines
+        var lines = fullText.Split('\n');
+        
+        // The cursor position Y gives us the line index directly
+        int currentLineIndex = Math.Min(cursorPos.Y, lines.Length - 1);
+        
+        // Find the query block that contains the current line
+        // A query block is separated by empty lines
+        int queryStartLine = currentLineIndex;
+        int queryEndLine = currentLineIndex;
+        
+        // Find start of query block (go backwards until empty line or start)
+        while (queryStartLine > 0 && !string.IsNullOrWhiteSpace(lines[queryStartLine - 1]))
         {
-            _userSettingsManager = userSettingsManager;
-            InitializeComponents();
-            SetupLayout();
-            SetKeyboard();
-            CanFocus = true;
+            queryStartLine--;
         }
-
-        private void InitializeComponents()
+        
+        // Find end of query block (go forwards until empty line or end)
+        while (queryEndLine < lines.Length - 1 && !string.IsNullOrWhiteSpace(lines[queryEndLine + 1]))
         {
-            _connectionLabel = new Label()
-            {
-                Text = "No connection",
-                X = 0,
-                Y = 0,
-                Width = Dim.Fill(),
-                Height = 1
-            };
-
-            _queryTextView = new TextView()
-            {
-                X = 0,
-                Y = 1,
-                Width = Dim.Fill(),
-                Height = Dim.Fill() - 1,
-                Text = "",
-            };
-
-            _shortcutsLabel = new Label()
-            {
-                Text = "F5: Execute | F12: Maximize/Restore",
-                X = 0,
-                Y = Pos.Bottom(_queryTextView),
-                Width = Dim.Fill(),
-                Height = 1,
-                SchemeName = "TopLevel"
-            };
-
-            _progressLabel = new Label()
-            {
-                X = 0,
-                Y = Pos.Bottom(_shortcutsLabel) - 1,
-                Width = Dim.Fill(),
-                Height = 1,
-                Visible = false
-            };
-
-            _temporaryMessageLabel = new Label()
-            {
-                X = 0,
-                Y = Pos.Bottom(_progressLabel) - 1,
-                Width = Dim.Fill(),
-                Height = 1,
-                Visible = false
-            };
+            queryEndLine++;
         }
+        
+        // Extract the query block
+        var queryLines = new string[queryEndLine - queryStartLine + 1];
+        Array.Copy(lines, queryStartLine, queryLines, 0, queryLines.Length);
+        
+        var query = string.Join("\n", queryLines).Trim();
+        
+        // If no query block found at cursor position, fallback to entire text
+        return string.IsNullOrWhiteSpace(query) ? fullText : query;
+    }
 
-        private void SetKeyboard()
+    public void SetConnection(KustoConnection connection)
+    {
+        _connectionLabel.Text = $"Connected: {connection.DisplayName} | {connection.Database}";
+    }
+
+    public void FocusEditor()
+    {
+        _queryTextView.SetFocus();
+    }
+
+    public void SetExecuting(bool isExecuting)
+    {
+        _isExecuting = isExecuting;
+        
+        if (isExecuting)
         {
-            _queryTextView.KeyBindings.ReplaceCommands(KeyCode.CtrlMask | Key.V.KeyCode, Command.Paste);
-            _queryTextView.KeyBindings.ReplaceCommands(KeyCode.CtrlMask | Key.C.KeyCode, Command.Copy);
-
-            _queryTextView.KeyDown += (sender, key) =>
-            {
-                if (key == Key.F5)
-                {
-                    OnExecuteClicked();
-                }
-                else if (key == Key.F12)
-                {
-                    MaximizeToggleRequested?.Invoke(this, EventArgs.Empty);
-                    key.Handled = true;
-                }
-                else if (key == Key.Esc)
-                {
-                    if (_isExecuting)
-                    {
-                        QueryCancelRequested?.Invoke(this, EventArgs.Empty);
-                    }
-                    else
-                    {
-                        EscapePressed?.Invoke(this, EventArgs.Empty);
-                    }
-                        
-                    key.Handled = true;
-                }
-            };
+            _progressLabel.Text = "⠋ Running query...";
+            _progressLabel.Visible = true;
+            StartProgressSpinner();
         }
-
-        private void SetupLayout()
+        else
         {
-            Add(_connectionLabel, _queryTextView, _shortcutsLabel, _progressLabel, _temporaryMessageLabel);
+            _progressLabel.Visible = false;
+            StopProgressSpinner();
         }
+    }
 
-        private void OnExecuteClicked()
-        {
-            var query = GetCurrentQuery();
-            if (!string.IsNullOrWhiteSpace(query))
-            {
-                SetExecuting(true);
-                QueryExecuteRequested?.Invoke(this, query);
-            }
-            else
-            {
-                MessageBox.ErrorQuery("Error", "Please enter a query to execute.", "OK");
-            }
-        }
+    private System.Threading.Timer? _spinnerTimer;
+    private readonly string[] _spinnerFrames = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
+    private int _spinnerIndex = 0;
 
-        public string GetCurrentQuery()
-        {
-            var fullText = _queryTextView.Text?.ToString() ?? "";
-            if (string.IsNullOrEmpty(fullText))
-                return "";
+    private void StartProgressSpinner()
+    {
+        _spinnerTimer = new System.Threading.Timer(UpdateSpinner, null, 0, 100);
+    }
 
-            // Get cursor position (Point with X=column, Y=row)
-            var cursorPos = _queryTextView.CursorPosition;
-            
-            // Split text into lines
-            var lines = fullText.Split('\n');
-            
-            // The cursor position Y gives us the line index directly
-            int currentLineIndex = Math.Min(cursorPos.Y, lines.Length - 1);
-            
-            // Find the query block that contains the current line
-            // A query block is separated by empty lines
-            int queryStartLine = currentLineIndex;
-            int queryEndLine = currentLineIndex;
-            
-            // Find start of query block (go backwards until empty line or start)
-            while (queryStartLine > 0 && !string.IsNullOrWhiteSpace(lines[queryStartLine - 1]))
-            {
-                queryStartLine--;
-            }
-            
-            // Find end of query block (go forwards until empty line or end)
-            while (queryEndLine < lines.Length - 1 && !string.IsNullOrWhiteSpace(lines[queryEndLine + 1]))
-            {
-                queryEndLine++;
-            }
-            
-            // Extract the query block
-            var queryLines = new string[queryEndLine - queryStartLine + 1];
-            Array.Copy(lines, queryStartLine, queryLines, 0, queryLines.Length);
-            
-            var query = string.Join("\n", queryLines).Trim();
-            
-            // If no query block found at cursor position, fallback to entire text
-            return string.IsNullOrWhiteSpace(query) ? fullText : query;
-        }
+    private void StopProgressSpinner()
+    {
+        _spinnerTimer?.Dispose();
+        _spinnerTimer = null;
+    }
 
-        public void SetConnection(KustoConnection connection)
-        {
-            _connectionLabel.Text = $"Connected: {connection.DisplayName} | {connection.Database}";
-        }
-
-        public void FocusEditor()
-        {
-            _queryTextView.SetFocus();
-        }
-
-        public void SetExecuting(bool isExecuting)
-        {
-            _isExecuting = isExecuting;
-            
-            if (isExecuting)
-            {
-                _progressLabel.Text = "⠋ Running query...";
-                _progressLabel.Visible = true;
-                StartProgressSpinner();
-            }
-            else
-            {
-                _progressLabel.Visible = false;
-                StopProgressSpinner();
-            }
-        }
-
-        private System.Threading.Timer? _spinnerTimer;
-        private readonly string[] _spinnerFrames = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
-        private int _spinnerIndex = 0;
-
-        private void StartProgressSpinner()
-        {
-            _spinnerTimer = new System.Threading.Timer(UpdateSpinner, null, 0, 100);
-        }
-
-        private void StopProgressSpinner()
-        {
-            _spinnerTimer?.Dispose();
-            _spinnerTimer = null;
-        }
-
-        private void UpdateSpinner(object? state)
-        {
-            Application.Invoke(() =>
-            {
-                if (_isExecuting && _progressLabel.Visible)
-                {
-                    _spinnerIndex = (_spinnerIndex + 1) % _spinnerFrames.Length;
-                    var currentMessage = _progressLabel.Text?.ToString() ?? "Running query...";
-                    // Extract the message part (everything after the spinner character and space)
-                    var messagePart = currentMessage.Length > 2 ? currentMessage.Substring(2) : "Running query...";
-                    _progressLabel.Text = $"{_spinnerFrames[_spinnerIndex]} {messagePart}";
-                    //_progressLabel.SetNeedsDisplay();
-                }
-            });
-        }
-
-        public void UpdateProgressMessage(string message)
+    private void UpdateSpinner(object? state)
+    {
+        Application.Invoke(() =>
         {
             if (_isExecuting && _progressLabel.Visible)
             {
-                _progressLabel.Text = $"{_spinnerFrames[_spinnerIndex]} {message}";
-             }
-        }
+                _spinnerIndex = (_spinnerIndex + 1) % _spinnerFrames.Length;
+                var currentMessage = _progressLabel.Text?.ToString() ?? "Running query...";
+                // Extract the message part (everything after the spinner character and space)
+                var messagePart = currentMessage.Length > 2 ? currentMessage.Substring(2) : "Running query...";
+                _progressLabel.Text = $"{_spinnerFrames[_spinnerIndex]} {messagePart}";
+                //_progressLabel.SetNeedsDisplay();
+            }
+        });
+    }
 
-        public void ShowTemporaryMessage(string message, int durationMs = 2000)
+    public void UpdateProgressMessage(string message)
+    {
+        if (_isExecuting && _progressLabel.Visible)
         {
-            // Cancel any existing timer
+            _progressLabel.Text = $"{_spinnerFrames[_spinnerIndex]} {message}";
+         }
+    }
+
+    public void ShowTemporaryMessage(string message, int durationMs = 2000)
+    {
+        // Cancel any existing timer
+        _temporaryMessageTimer?.Dispose();
+        
+        // Show the message
+        _temporaryMessageLabel.Text = message;
+        _temporaryMessageLabel.Visible = true;
+        
+        // Set up timer to hide the message after the specified duration
+        _temporaryMessageTimer = new System.Threading.Timer(HideTemporaryMessage, null, durationMs, System.Threading.Timeout.Infinite);
+    }
+
+    private void HideTemporaryMessage(object? state)
+    {
+        Application.Invoke(() =>
+        {
+            _temporaryMessageLabel.Visible = false;
             _temporaryMessageTimer?.Dispose();
-            
-            // Show the message
-            _temporaryMessageLabel.Text = message;
-            _temporaryMessageLabel.Visible = true;
-            
-            // Set up timer to hide the message after the specified duration
-            _temporaryMessageTimer = new System.Threading.Timer(HideTemporaryMessage, null, durationMs, System.Threading.Timeout.Infinite);
-        }
+            _temporaryMessageTimer = null;
+        });
+    }
 
-        private void HideTemporaryMessage(object? state)
+    public async void LoadLastQueryAsync()
+    {
+        if (_userSettingsManager != null)
         {
-            Application.Invoke(() =>
+            try
             {
-                _temporaryMessageLabel.Visible = false;
-                _temporaryMessageTimer?.Dispose();
-                _temporaryMessageTimer = null;
-            });
-        }
-
-        public async void LoadLastQueryAsync()
-        {
-            if (_userSettingsManager != null)
-            {
-                try
+                var lastQuery = await _userSettingsManager.GetLastQueryAsync();
+                if (!string.IsNullOrEmpty(lastQuery))
                 {
-                    var lastQuery = await _userSettingsManager.GetLastQueryAsync();
-                    if (!string.IsNullOrEmpty(lastQuery))
+                    Application.Invoke(() =>
                     {
-                        Application.Invoke(() =>
-                        {
-                            _queryTextView.Text = lastQuery;
-                        });
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // Silently fail - don't crash the app if settings can't be loaded
-                    Console.WriteLine($"Warning: Failed to load last query: {ex.Message}");
+                        _queryTextView.Text = lastQuery;
+                    });
                 }
             }
-        }
-
-        public async void SaveCurrentQueryAsync()
-        {
-            if (_userSettingsManager != null)
+            catch (Exception ex)
             {
-                try
-                {
-                    var currentQuery = _queryTextView.Text?.ToString() ?? string.Empty;
-                    await _userSettingsManager.SaveLastQueryAsync(currentQuery);
-                }
-                catch (Exception ex)
-                {
-                    // Silently fail - don't crash the app if settings can't be saved
-                    Console.WriteLine($"Warning: Failed to save query: {ex.Message}");
-                }
+                // Silently fail - don't crash the app if settings can't be loaded
+                Console.WriteLine($"Warning: Failed to load last query: {ex.Message}");
             }
         }
+    }
 
-        public void SetQueryText(string query)
+    public async void SaveCurrentQueryAsync()
+    {
+        if (_userSettingsManager != null)
         {
-            _queryTextView.Text = query ?? string.Empty;
-        }
-
-        public string GetQueryText()
-        {
-            return _queryTextView.Text?.ToString() ?? string.Empty;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
+            try
             {
-                // Save query before disposing
-                SaveCurrentQueryAsync();
-                _temporaryMessageTimer?.Dispose();
-                _spinnerTimer?.Dispose();
+                var currentQuery = _queryTextView.Text?.ToString() ?? string.Empty;
+                await _userSettingsManager.SaveLastQueryAsync(currentQuery);
             }
-            base.Dispose(disposing);
+            catch (Exception ex)
+            {
+                // Silently fail - don't crash the app if settings can't be saved
+                Console.WriteLine($"Warning: Failed to save query: {ex.Message}");
+            }
         }
+    }
+
+    public void SetQueryText(string query)
+    {
+        _queryTextView.Text = query ?? string.Empty;
+    }
+
+    public string GetQueryText()
+    {
+        return _queryTextView.Text?.ToString() ?? string.Empty;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Save query before disposing
+            SaveCurrentQueryAsync();
+            _temporaryMessageTimer?.Dispose();
+            _spinnerTimer?.Dispose();
+        }
+        base.Dispose(disposing);
     }
 }

--- a/src/KustoTerminal.UI/Panes/ResultsPane.cs
+++ b/src/KustoTerminal.UI/Panes/ResultsPane.cs
@@ -12,700 +12,699 @@ using KustoTerminal.UI.Dialogs;
 using Terminal.Gui.Input;
 using Terminal.Gui.Drivers;
 
-namespace KustoTerminal.UI.Panes
+namespace KustoTerminal.UI.Panes;
+
+public class ResultsPane : BasePane
 {
-    public class ResultsPane : BasePane
+private TableView _tableView;
+private Label _statusLabel;
+private TextView _errorLabel;
+private Label _shortcutsLabel;
+private TextField _searchField;
+private Label _searchLabel;
+
+private QueryResult? _currentResult;
+private DataTable? _originalData;
+private HashSet<string> _selectedColumns = new HashSet<string>();
+private bool _searchVisible = false;
+public event EventHandler? MaximizeToggleRequested;
+
+public ResultsPane()
+{
+    InitializeComponents();
+    SetupLayout();
+    SetKeyboard();
+    
+    CanFocus = true;
+    TabStop = TabBehavior.TabStop;
+}
+
+private void InitializeComponents()
+{
+    _statusLabel = new Label()
     {
-        private TableView _tableView;
-        private Label _statusLabel;
-        private TextView _errorLabel;
-        private Label _shortcutsLabel;
-        private TextField _searchField;
-        private Label _searchLabel;
-        
-        private QueryResult? _currentResult;
-        private DataTable? _originalData;
-        private HashSet<string> _selectedColumns = new HashSet<string>();
-        private bool _searchVisible = false;
-        public event EventHandler? MaximizeToggleRequested;
+        Text = "No results",
+        X = 0,
+        Y = 0,
+        Width = Dim.Fill(),
+        Height = 1
+    };
 
-        public ResultsPane()
+    _errorLabel = new TextView()
+    {
+        Text = "",
+        X = 0,
+        Y = 1,  // Position where table view is
+        Width = Dim.Fill(),
+        Height = Dim.Fill() - 1,  // Take up the space normally used by table view
+        Visible = false,
+        SchemeName = "Error",
+        ReadOnly = true,
+    };
+
+    _tableView = new TableView()
+    {
+        X = 0,
+        Y = 1,
+        Width = Dim.Fill(),
+        Height = Dim.Fill() - 1,
+        FullRowSelect = false,
+        MultiSelect = false,
+    };
+
+    _shortcutsLabel = new Label()
+    {
+        Text = "/: Filter | Ctrl+L: Columns | Ctrl+R: Row Select | Ctrl+J: JSON Viewer | Ctrl+S: Export | F12: Maximize/Restore",
+        X = 0,
+        Y = Pos.Bottom(_tableView),
+        Width = Dim.Fill(),
+        Height = 1,
+        SchemeName = "TopLevel"
+    };
+    
+    _searchLabel = new Label()
+    {
+        Text = "Search:",
+        X = 0,
+        Y = Pos.Bottom(_tableView),
+        Width = 8,
+        Height = 1,
+        Visible = false
+    };
+
+    _searchField = new TextField()
+    {
+        X = 0,
+        Y = Pos.Bottom(_tableView) - 1,
+        Width = Dim.Fill(),
+        Height = 1,
+        Visible = false
+    };
+
+    _searchField.TextChanged += OnSearchTextChanged;
+}
+
+private void SetKeyboard()
+{
+    KeyDown += (sender, key) =>
+    {
+        if (Key.TryParse("/", out var k) && key == k)
         {
-            InitializeComponents();
-            SetupLayout();
-            SetKeyboard();
-            
-            CanFocus = true;
-            TabStop = TabBehavior.TabStop;
+            ToggleSearch();
+            key.Handled = true;
         }
-
-        private void InitializeComponents()
+        else if (key.KeyCode == (KeyCode.CtrlMask | Key.S.KeyCode))
         {
-            _statusLabel = new Label()
-            {
-                Text = "No results",
-                X = 0,
-                Y = 0,
-                Width = Dim.Fill(),
-                Height = 1
-            };
-
-            _errorLabel = new TextView()
-            {
-                Text = "",
-                X = 0,
-                Y = 1,  // Position where table view is
-                Width = Dim.Fill(),
-                Height = Dim.Fill() - 1,  // Take up the space normally used by table view
-                Visible = false,
-                SchemeName = "Error",
-                ReadOnly = true,
-            };
-
-            _tableView = new TableView()
-            {
-                X = 0,
-                Y = 1,
-                Width = Dim.Fill(),
-                Height = Dim.Fill() - 1,
-                FullRowSelect = false,
-                MultiSelect = false,
-            };
-
-            _shortcutsLabel = new Label()
-            {
-                Text = "/: Filter | Ctrl+L: Columns | Ctrl+R: Row Select | Ctrl+J: JSON Viewer | Ctrl+S: Export | F12: Maximize/Restore",
-                X = 0,
-                Y = Pos.Bottom(_tableView),
-                Width = Dim.Fill(),
-                Height = 1,
-                SchemeName = "TopLevel"
-            };
-            
-            _searchLabel = new Label()
-            {
-                Text = "Search:",
-                X = 0,
-                Y = Pos.Bottom(_tableView),
-                Width = 8,
-                Height = 1,
-                Visible = false
-            };
-
-            _searchField = new TextField()
-            {
-                X = 0,
-                Y = Pos.Bottom(_tableView) - 1,
-                Width = Dim.Fill(),
-                Height = 1,
-                Visible = false
-            };
-
-            _searchField.TextChanged += OnSearchTextChanged;
+            OnExportClicked();
+            key.Handled = true;
         }
-
-        private void SetKeyboard()
+        else if (key == Key.F12)
         {
-            KeyDown += (sender, key) =>
-            {
-                if (Key.TryParse("/", out var k) && key == k)
-                {
-                    ToggleSearch();
-                    key.Handled = true;
-                }
-                else if (key.KeyCode == (KeyCode.CtrlMask | Key.S.KeyCode))
-                {
-                    OnExportClicked();
-                    key.Handled = true;
-                }
-                else if (key == Key.F12)
-                {
-                    MaximizeToggleRequested?.Invoke(this, EventArgs.Empty);
-                    key.Handled = true;
-                }
-                else if (key.KeyCode == (KeyCode.CtrlMask | Key.L.KeyCode))
-                {
-                    OnColumnSelectorClicked();
-                    key.Handled = true;
-                }
-            };
-
-            _searchField.KeyDown += (sender, key) =>
-            {
-                if (key == Key.Esc)
-                {
-                    HideSearch();
-                    key.Handled = true;
-                }
-            };
-
-            _tableView.KeyDown += (sender, key) =>
-            {
-                if (key == (KeyCode.CtrlMask | Key.C.KeyCode))
-                {
-                    OnCopyCellClicked();
-                    key.Handled = true;
-                } else if (key == (KeyCode.CtrlMask | Key.R.KeyCode))
-                {
-                    SwitchToRowMode();
-                    key.Handled = true;
-                } else if (key == Key.F11)
-                {
-                    MaximizeToggleRequested?.Invoke(this, EventArgs.Empty);
-                    key.Handled = true;
-                } else if (key == Key.Esc)
-                {
-                    SwitchToCellMode();
-                    key.Handled = true;
-                } else if (key == Key.Enter)
-                {
-                    OnViewCellClicked();
-                    key.Handled = true;
-                } else if (key.KeyCode == (KeyCode.CtrlMask | Key.Enter.KeyCode))
-                {
-                    OnViewJsonClicked();
-                    key.Handled = true;
-                } else if (key.KeyCode == (KeyCode.CtrlMask | Key.L.KeyCode))
-                {
-                    OnColumnSelectorClicked();
-                    key.Handled = true;
-                }
-            };
+            MaximizeToggleRequested?.Invoke(this, EventArgs.Empty);
+            key.Handled = true;
         }
-
-        private void SetupLayout()
+        else if (key.KeyCode == (KeyCode.CtrlMask | Key.L.KeyCode))
         {
-            Add(_statusLabel, _errorLabel, _tableView, _searchLabel, _searchField, _shortcutsLabel);
+            OnColumnSelectorClicked();
+            key.Handled = true;
         }
+    };
 
-        public void DisplayResult(QueryResult result)
+    _searchField.KeyDown += (sender, key) =>
+    {
+        if (key == Key.Esc)
         {
-            Clear();
-            _currentResult = result;
-
-            if (!result.IsSuccess)
-            {
-                DisplayError(result);
-                return;
-            }
-
-            if (result.Data == null || result.Data.Rows.Count == 0)
-            {
-                DisplayEmpty(result);
-                return;
-            }
-
-            DisplayData(result);
-        }
-
-        private void DisplayData(QueryResult result)
-        {
-            try
-            {
-                // Hide error label and show table view
-                _errorLabel.Visible = false;
-                _tableView.Visible = true;
-                _statusLabel.Visible = true;
-                
-                var dataTable = result.Data!;
-                _originalData = dataTable.Copy(); // Keep a copy of the original data
-                
-                // Initialize selected columns if not set
-                if (_selectedColumns.Count == 0)
-                {
-                    foreach (DataColumn column in dataTable.Columns)
-                    {
-                        _selectedColumns.Add(column.ColumnName);
-                    }
-                }
-                
-                // Apply column filtering
-                var filteredTable = ApplyColumnFilter(dataTable);
-                _tableView.Table = new DataTableSource(filteredTable);
-
-                var statusText = $"Rows: {result.RowCount:N0} | Columns: {result.ColumnCount} | Duration: {result.Duration.TotalMilliseconds:F0}ms";
-                if (!string.IsNullOrEmpty(result.ClientRequestId))
-                {
-                    statusText += $" | ClientRequestId: {result.ClientRequestId}";
-                }
-                _statusLabel.Text = statusText;
-            }
-            catch (Exception ex)
-            {
-                // Hide table view and show error label for display errors
-                _tableView.Visible = false;
-                _errorLabel.Visible = true;
-                _errorLabel.Text = $"Error displaying results: {ex.Message}";
-                _statusLabel.Text = $"Error occurred while displaying results | Duration: {result.Duration.TotalMilliseconds:F0}ms";
-            }
-        }
-
-        private void DisplayError(QueryResult result)
-        {
-            // Hide table view and show error label in its place
-            _tableView.Visible = false;
-            _errorLabel.Visible = true;
-            _errorLabel.Text = $"Query failed: {result.ErrorMessage}";
-            
-            // Keep status label visible for other information
-            var statusText = "Error occurred during query execution";
-            if (!string.IsNullOrEmpty(result.ClientRequestId))
-            {
-                statusText += $" | ClientRequestId: {result.ClientRequestId}";
-            }
-            _statusLabel.Text = statusText;
-        }
-
-        private void DisplayEmpty(QueryResult result)
-        {
-            // Hide error label and show table view
-            _errorLabel.Visible = false;
-            _tableView.Visible = true;
-            _statusLabel.Visible = true;
-            
-            var statusText = $"No results returned | Duration: {result.Duration.TotalMilliseconds:F0}ms";
-            if (!string.IsNullOrEmpty(result.ClientRequestId))
-            {
-                statusText += $" | ClientRequestId: {result.ClientRequestId}";
-            }
-            _statusLabel.Text = statusText;
-            
-            // Show empty table with column headers if available
-            if (result.Data != null && result.Data.Columns.Count > 0)
-            {
-                _tableView.Table = new DataTableSource(result.Data);
-            }
-            else
-            {
-                _tableView.Table = new DataTableSource(new DataTable());
-            }
-        }
-
-        public new void Clear()
-        {
-            _currentResult = null;
-            _originalData = null;
-            _selectedColumns.Clear();
-            _tableView.Table = new DataTableSource(new DataTable());
-            
-            // Reset to showing table view and status label, hide error label
-            _errorLabel.Visible = false;
-            _tableView.Visible = true;
-            _statusLabel.Visible = true;
-            _statusLabel.Text = "No results";
-            
             HideSearch();
+            key.Handled = true;
         }
+    };
 
-        private void OnExportClicked()
+    _tableView.KeyDown += (sender, key) =>
+    {
+        if (key == (KeyCode.CtrlMask | Key.C.KeyCode))
         {
-            if (_currentResult?.Data == null) return;
-
-            var dialog = new SaveDialog()
-            {
-                Title = "Export Results",
-                AllowedTypes = new List<IAllowedType>()
-                {
-                    new AllowedType("csv", ".csv"),
-                    new AllowedType("json", ".json"),
-                    new AllowedType("tsv", ".tsv"),
-                },
-                OpenMode = OpenMode.File,
-            };
-
-            dialog.Path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "results.csv");
-
-            Application.Run(dialog);
-
-            if (!dialog.Canceled && !string.IsNullOrEmpty(dialog.FileName))
-            {
-                try
-                {
-                    ExportData(_currentResult.Data, dialog.FileName.ToString());
-                    MessageBox.Query("Export", "Results exported successfully!", "OK");
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.ErrorQuery("Export Error", $"Failed to export results: {ex.Message}", "OK");
-                }
-            }
+            OnCopyCellClicked();
+            key.Handled = true;
+        } else if (key == (KeyCode.CtrlMask | Key.R.KeyCode))
+        {
+            SwitchToRowMode();
+            key.Handled = true;
+        } else if (key == Key.F11)
+        {
+            MaximizeToggleRequested?.Invoke(this, EventArgs.Empty);
+            key.Handled = true;
+        } else if (key == Key.Esc)
+        {
+            SwitchToCellMode();
+            key.Handled = true;
+        } else if (key == Key.Enter)
+        {
+            OnViewCellClicked();
+            key.Handled = true;
+        } else if (key.KeyCode == (KeyCode.CtrlMask | Key.Enter.KeyCode))
+        {
+            OnViewJsonClicked();
+            key.Handled = true;
+        } else if (key.KeyCode == (KeyCode.CtrlMask | Key.L.KeyCode))
+        {
+            OnColumnSelectorClicked();
+            key.Handled = true;
         }
+    };
+}
 
-        private void ExportData(DataTable dataTable, string fileName)
-        {
-            var extension = System.IO.Path.GetExtension(fileName).ToLowerInvariant();
-            
-            switch (extension)
-            {
-                case ".csv":
-                    ExportToCsv(dataTable, fileName);
-                    break;
-                case ".json":
-                    ExportToJson(dataTable, fileName);
-                    break;
-                case ".tsv":
-                    ExportToTsv(dataTable, fileName);
-                    break;
-                default:
-                    throw new ArgumentException($"Unsupported file format: {extension}");
-            }
-        }
+private void SetupLayout()
+{
+    Add(_statusLabel, _errorLabel, _tableView, _searchLabel, _searchField, _shortcutsLabel);
+}
 
-        private void ExportToCsv(DataTable dataTable, string fileName)
-        {
-            using var writer = new System.IO.StreamWriter(fileName);
-            
-            // Write headers
-            var headers = dataTable.Columns.Cast<DataColumn>().Select(column => $"\"{column.ColumnName}\"");
-            writer.WriteLine(string.Join(",", headers));
-            
-            // Write rows
-            foreach (DataRow row in dataTable.Rows)
-            {
-                var fields = row.ItemArray.Select(field => $"\"{field?.ToString()?.Replace("\"", "\"\"")}\"");
-                writer.WriteLine(string.Join(",", fields));
-            }
-        }
+public void DisplayResult(QueryResult result)
+{
+    Clear();
+    _currentResult = result;
 
-        private void ExportToTsv(DataTable dataTable, string fileName)
+    if (!result.IsSuccess)
+    {
+        DisplayError(result);
+        return;
+    }
+
+    if (result.Data == null || result.Data.Rows.Count == 0)
+    {
+        DisplayEmpty(result);
+        return;
+    }
+
+    DisplayData(result);
+}
+
+private void DisplayData(QueryResult result)
+{
+    try
+    {
+        // Hide error label and show table view
+        _errorLabel.Visible = false;
+        _tableView.Visible = true;
+        _statusLabel.Visible = true;
+        
+        var dataTable = result.Data!;
+        _originalData = dataTable.Copy(); // Keep a copy of the original data
+        
+        // Initialize selected columns if not set
+        if (_selectedColumns.Count == 0)
         {
-            using var writer = new System.IO.StreamWriter(fileName);
-            
-            // Write headers
-            var headers = dataTable.Columns.Cast<DataColumn>().Select(column => column.ColumnName);
-            writer.WriteLine(string.Join("\t", headers));
-            
-            // Write rows
-            foreach (DataRow row in dataTable.Rows)
+            foreach (DataColumn column in dataTable.Columns)
             {
-                var fields = row.ItemArray.Select(field => field?.ToString()?.Replace("\t", " "));
-                writer.WriteLine(string.Join("\t", fields));
+                _selectedColumns.Add(column.ColumnName);
             }
         }
+        
+        // Apply column filtering
+        var filteredTable = ApplyColumnFilter(dataTable);
+        _tableView.Table = new DataTableSource(filteredTable);
 
-        private void ExportToJson(DataTable dataTable, string fileName)
+        var statusText = $"Rows: {result.RowCount:N0} | Columns: {result.ColumnCount} | Duration: {result.Duration.TotalMilliseconds:F0}ms";
+        if (!string.IsNullOrEmpty(result.ClientRequestId))
         {
-            var rows = new System.Collections.Generic.List<object>();
-            
-            foreach (DataRow row in dataTable.Rows)
-            {
-                var rowObject = new System.Collections.Generic.Dictionary<string, object?>();
-                
-                for (int i = 0; i < dataTable.Columns.Count; i++)
-                {
-                    rowObject[dataTable.Columns[i].ColumnName] = row[i] == DBNull.Value ? null : row[i];
-                }
-                
-                rows.Add(rowObject);
-            }
-            
-            var json = Newtonsoft.Json.JsonConvert.SerializeObject(rows, Newtonsoft.Json.Formatting.Indented);
-            System.IO.File.WriteAllText(fileName, json);
+            statusText += $" | ClientRequestId: {result.ClientRequestId}";
         }
+        _statusLabel.Text = statusText;
+    }
+    catch (Exception ex)
+    {
+        // Hide table view and show error label for display errors
+        _tableView.Visible = false;
+        _errorLabel.Visible = true;
+        _errorLabel.Text = $"Error displaying results: {ex.Message}";
+        _statusLabel.Text = $"Error occurred while displaying results | Duration: {result.Duration.TotalMilliseconds:F0}ms";
+    }
+}
 
-        private void OnCopyCellClicked()
+private void DisplayError(QueryResult result)
+{
+    // Hide table view and show error label in its place
+    _tableView.Visible = false;
+    _errorLabel.Visible = true;
+    _errorLabel.Text = $"Query failed: {result.ErrorMessage}";
+    
+    // Keep status label visible for other information
+    var statusText = "Error occurred during query execution";
+    if (!string.IsNullOrEmpty(result.ClientRequestId))
+    {
+        statusText += $" | ClientRequestId: {result.ClientRequestId}";
+    }
+    _statusLabel.Text = statusText;
+}
+
+private void DisplayEmpty(QueryResult result)
+{
+    // Hide error label and show table view
+    _errorLabel.Visible = false;
+    _tableView.Visible = true;
+    _statusLabel.Visible = true;
+    
+    var statusText = $"No results returned | Duration: {result.Duration.TotalMilliseconds:F0}ms";
+    if (!string.IsNullOrEmpty(result.ClientRequestId))
+    {
+        statusText += $" | ClientRequestId: {result.ClientRequestId}";
+    }
+    _statusLabel.Text = statusText;
+    
+    // Show empty table with column headers if available
+    if (result.Data != null && result.Data.Columns.Count > 0)
+    {
+        _tableView.Table = new DataTableSource(result.Data);
+    }
+    else
+    {
+        _tableView.Table = new DataTableSource(new DataTable());
+    }
+}
+
+public new void Clear()
+{
+    _currentResult = null;
+    _originalData = null;
+    _selectedColumns.Clear();
+    _tableView.Table = new DataTableSource(new DataTable());
+    
+    // Reset to showing table view and status label, hide error label
+    _errorLabel.Visible = false;
+    _tableView.Visible = true;
+    _statusLabel.Visible = true;
+    _statusLabel.Text = "No results";
+    
+    HideSearch();
+}
+
+private void OnExportClicked()
+{
+    if (_currentResult?.Data == null) return;
+
+    var dialog = new SaveDialog()
+    {
+        Title = "Export Results",
+        AllowedTypes = new List<IAllowedType>()
         {
-            if (_currentResult?.Data == null || _tableView.Table == null)
-            {
-                return;
-            }
+            new AllowedType("csv", ".csv"),
+            new AllowedType("json", ".json"),
+            new AllowedType("tsv", ".tsv"),
+        },
+        OpenMode = OpenMode.File,
+    };
 
-            var selectedRow = _tableView.SelectedRow;
-            var selectedCol = _tableView.SelectedColumn;
+    dialog.Path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "results.csv");
 
-            var cellValue = _tableView.Table[selectedRow,selectedCol]?.ToString() ?? "";
+    Application.Run(dialog);
 
-            try
-            {
-                Clipboard.Contents = cellValue;
-            }
-            catch { }
+    if (!dialog.Canceled && !string.IsNullOrEmpty(dialog.FileName))
+    {
+        try
+        {
+            ExportData(_currentResult.Data, dialog.FileName.ToString());
+            MessageBox.Query("Export", "Results exported successfully!", "OK");
         }
-
-        private void SwitchToRowMode()
+        catch (Exception ex)
         {
-            _tableView.FullRowSelect = true;
-            _tableView.SetNeedsLayout();
-        }
-
-        private void SwitchToCellMode()
-        {
-            _tableView.FullRowSelect = false;
-            _tableView.SetNeedsLayout();
-        }
-
-        private void OnViewCellClicked()
-        {
-            if (_currentResult?.Data == null || _tableView.Table == null)
-            {
-                return;
-            }
-
-            var selectedRow = _tableView.SelectedRow;
-            var selectedCol = _tableView.SelectedColumn;
-
-            var cellValue = _tableView.Table[selectedRow, selectedCol]?.ToString() ?? "";
-            var columnName = _tableView.Table.ColumnNames.ElementAt(selectedCol);
-
-            ShowCellDetailDialog(columnName, cellValue);
-        }
-
-        private void OnViewJsonClicked()
-        {
-            if (_currentResult?.Data == null || _tableView.Table == null)
-            {
-                return;
-            }
-
-            var selectedRow = _tableView.SelectedRow;
-            var selectedCol = _tableView.SelectedColumn;
-
-            var cellValue = _tableView.Table[selectedRow, selectedCol]?.ToString() ?? "";
-            var columnName = _tableView.Table.ColumnNames.ElementAt(selectedCol);
-
-            // Check if content is JSON
-            if (IsValidJson(cellValue))
-            {
-                ShowJsonTreeViewDialog(columnName, cellValue);
-            }
-            else
-            {
-                // Show a brief message that the cell doesn't contain JSON
-                MessageBox.Query("Not JSON", "The selected cell does not contain valid JSON data.", "OK");
-            }
-        }
-
-        private void ShowCellDetailDialog(string columnName, string cellValue)
-        {
-            // Default text view dialog
-            var dialog = new Dialog()
-            {
-                Title = $"Cell Content: {columnName}",
-                Height = 20,
-                Width = Dim.Percent(80),
-                Modal = true,
-            };
-            var textView = new TextView()
-            {
-                X = 1,
-                Y = 1,
-                Width = Dim.Fill(1),
-                Height = Dim.Fill(2),
-                Text = cellValue,
-                ReadOnly = true,
-                WordWrap = true
-            };
-
-            dialog.Add(textView);
-            textView.SetFocus();
-
-            Application.Run(dialog);
-        }
-
-        private void ShowJsonTreeViewDialog(string columnName, string jsonContent)
-        {
-            var dialog = new JsonTreeViewDialog(columnName, jsonContent);
-            Application.Run(dialog);
-        }
-
-        private static bool IsValidJson(string value)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-                return false;
-
-            value = value.Trim();
-            
-            // Quick check for JSON-like structure
-            if (!(value.StartsWith("{") && value.EndsWith("}")) &&
-                !(value.StartsWith("[") && value.EndsWith("]")))
-                return false;
-
-            try
-            {
-                System.Text.Json.JsonDocument.Parse(value);
-                return true;
-            }
-            catch (System.Text.Json.JsonException)
-            {
-                return false;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-
-        private void ToggleSearch()
-        {
-            if (_searchVisible)
-            {
-                _searchField.SetFocus();
-            }
-            else
-            {
-                ShowSearch();
-            }
-        }
-
-        private void ShowSearch()
-        {
-            if (_currentResult?.Data == null || _originalData == null)
-                return;
-
-            _searchVisible = true;
-            _searchLabel.Visible = true;
-            _searchField.Visible = true;
-            _searchField.SetFocus();
-        }
-
-        private void HideSearch()
-        {
-            _searchVisible = false;
-            _searchLabel.Visible = false;
-            _searchField.Visible = false;
-            _searchField.Text = "";
-            if (_originalData != null)
-            {
-                _tableView.Table = new DataTableSource(_originalData);
-                UpdateStatusForOriginalData();
-            }
-            
-            _tableView.SetFocus();
-        }
-
-        private void OnSearchTextChanged(object? sender, EventArgs e)
-        {
-            PerformSearch();
-        }
-
-        private void PerformSearch()
-        {
-            if (_originalData == null || !_searchVisible)
-                return;
-
-            var searchText = _searchField.Text.ToString();
-            
-            if (string.IsNullOrWhiteSpace(searchText))
-            {
-                // Show all data when search is empty
-                _tableView.Table = new DataTableSource(_originalData);
-                UpdateStatusForOriginalData();
-                return;
-            }
-
-            try
-            {
-                // Create a filtered view of the data
-                var filteredTable = _originalData.Clone();
-                
-                foreach (DataRow row in _originalData.Rows)
-                {
-                    bool rowMatches = false;
-                    
-                    // Check each column for the search text (case-insensitive)
-                    foreach (var item in row.ItemArray)
-                    {
-                        var cellValue = item?.ToString() ?? "";
-                        if (cellValue.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) >= 0)
-                        {
-                            rowMatches = true;
-                            break;
-                        }
-                    }
-                    
-                    if (rowMatches)
-                    {
-                        filteredTable.ImportRow(row);
-                    }
-                }
-                
-                _tableView.Table = new DataTableSource(filteredTable);
-                UpdateStatusForFilteredData(filteredTable.Rows.Count, searchText);
-            }
-            catch (Exception ex)
-            {
-                // Hide table view and show error label for search errors
-                _tableView.Visible = false;
-                _errorLabel.Visible = true;
-                _errorLabel.Text = $"Search error: {ex.Message}";
-                _statusLabel.Text = "Error occurred during search";
-            }
-        }
-
-        private void UpdateStatusForOriginalData()
-        {
-            if (_currentResult != null)
-            {
-                var statusText = $"Rows: {_currentResult.RowCount:N0} | Columns: {_currentResult.ColumnCount} | Duration: {_currentResult.Duration.TotalMilliseconds:F0}ms";
-                if (!string.IsNullOrEmpty(_currentResult.ClientRequestId))
-                {
-                    statusText += $" | ClientRequestId: {_currentResult.ClientRequestId}";
-                }
-                _statusLabel.Text = statusText;
-            }
-        }
-
-        private void UpdateStatusForFilteredData(int filteredRowCount, string searchText)
-        {
-            if (_currentResult != null)
-            {
-                var statusText = $"Filtered: {filteredRowCount:N0} of {_currentResult.RowCount:N0} rows | Search: \"{searchText}\" | Columns: {_currentResult.ColumnCount} | Duration: {_currentResult.Duration.TotalMilliseconds:F0}ms";
-                if (!string.IsNullOrEmpty(_currentResult.ClientRequestId))
-                {
-                    statusText += $" | ClientRequestId: {_currentResult.ClientRequestId}";
-                }
-                _statusLabel.Text = statusText;
-            }
-        }
-
-        private void OnColumnSelectorClicked()
-        {
-            if (_originalData == null) return;
-
-            var dialog = new ColumnSelectorDialog(_originalData, _selectedColumns);
-            Application.Run(dialog);
-
-            // Update selected columns and refresh display
-            _selectedColumns = dialog.SelectedColumns;
-            
-            if (_currentResult != null)
-            {
-                DisplayData(_currentResult);
-            }
-        }
-
-        private DataTable ApplyColumnFilter(DataTable sourceTable)
-        {
-            if (_selectedColumns.Count == 0 || _selectedColumns.Count == sourceTable.Columns.Count)
-            {
-                // If no columns selected or all columns selected, return the original table
-                return sourceTable;
-            }
-
-            // Create a new table with only selected columns
-            var filteredTable = new DataTable();
-            
-            // Add selected columns to the new table
-            foreach (DataColumn column in sourceTable.Columns)
-            {
-                if (_selectedColumns.Contains(column.ColumnName))
-                {
-                    filteredTable.Columns.Add(column.ColumnName, column.DataType);
-                }
-            }
-
-            // Copy rows with only selected columns
-            foreach (DataRow sourceRow in sourceTable.Rows)
-            {
-                var newRow = filteredTable.NewRow();
-                foreach (DataColumn column in filteredTable.Columns)
-                {
-                    newRow[column.ColumnName] = sourceRow[column.ColumnName];
-                }
-                filteredTable.Rows.Add(newRow);
-            }
-
-            return filteredTable;
+            MessageBox.ErrorQuery("Export Error", $"Failed to export results: {ex.Message}", "OK");
         }
     }
+}
+
+private void ExportData(DataTable dataTable, string fileName)
+{
+    var extension = System.IO.Path.GetExtension(fileName).ToLowerInvariant();
+    
+    switch (extension)
+    {
+        case ".csv":
+            ExportToCsv(dataTable, fileName);
+            break;
+        case ".json":
+            ExportToJson(dataTable, fileName);
+            break;
+        case ".tsv":
+            ExportToTsv(dataTable, fileName);
+            break;
+        default:
+            throw new ArgumentException($"Unsupported file format: {extension}");
+    }
+}
+
+private void ExportToCsv(DataTable dataTable, string fileName)
+{
+    using var writer = new System.IO.StreamWriter(fileName);
+    
+    // Write headers
+    var headers = dataTable.Columns.Cast<DataColumn>().Select(column => $"\"{column.ColumnName}\"");
+    writer.WriteLine(string.Join(",", headers));
+    
+    // Write rows
+    foreach (DataRow row in dataTable.Rows)
+    {
+        var fields = row.ItemArray.Select(field => $"\"{field?.ToString()?.Replace("\"", "\"\"")}\"");
+        writer.WriteLine(string.Join(",", fields));
+    }
+}
+
+private void ExportToTsv(DataTable dataTable, string fileName)
+{
+    using var writer = new System.IO.StreamWriter(fileName);
+    
+    // Write headers
+    var headers = dataTable.Columns.Cast<DataColumn>().Select(column => column.ColumnName);
+    writer.WriteLine(string.Join("\t", headers));
+    
+    // Write rows
+    foreach (DataRow row in dataTable.Rows)
+    {
+        var fields = row.ItemArray.Select(field => field?.ToString()?.Replace("\t", " "));
+        writer.WriteLine(string.Join("\t", fields));
+    }
+}
+
+private void ExportToJson(DataTable dataTable, string fileName)
+{
+    var rows = new System.Collections.Generic.List<object>();
+    
+    foreach (DataRow row in dataTable.Rows)
+    {
+        var rowObject = new System.Collections.Generic.Dictionary<string, object?>();
+        
+        for (int i = 0; i < dataTable.Columns.Count; i++)
+        {
+            rowObject[dataTable.Columns[i].ColumnName] = row[i] == DBNull.Value ? null : row[i];
+        }
+        
+        rows.Add(rowObject);
+    }
+    
+    var json = Newtonsoft.Json.JsonConvert.SerializeObject(rows, Newtonsoft.Json.Formatting.Indented);
+    System.IO.File.WriteAllText(fileName, json);
+}
+
+private void OnCopyCellClicked()
+{
+    if (_currentResult?.Data == null || _tableView.Table == null)
+    {
+        return;
+    }
+
+    var selectedRow = _tableView.SelectedRow;
+    var selectedCol = _tableView.SelectedColumn;
+
+    var cellValue = _tableView.Table[selectedRow,selectedCol]?.ToString() ?? "";
+
+    try
+    {
+        Clipboard.Contents = cellValue;
+    }
+    catch { }
+}
+
+private void SwitchToRowMode()
+{
+    _tableView.FullRowSelect = true;
+    _tableView.SetNeedsLayout();
+}
+
+private void SwitchToCellMode()
+{
+    _tableView.FullRowSelect = false;
+    _tableView.SetNeedsLayout();
+}
+
+private void OnViewCellClicked()
+{
+    if (_currentResult?.Data == null || _tableView.Table == null)
+    {
+        return;
+    }
+
+    var selectedRow = _tableView.SelectedRow;
+    var selectedCol = _tableView.SelectedColumn;
+
+    var cellValue = _tableView.Table[selectedRow, selectedCol]?.ToString() ?? "";
+    var columnName = _tableView.Table.ColumnNames.ElementAt(selectedCol);
+
+    ShowCellDetailDialog(columnName, cellValue);
+}
+
+private void OnViewJsonClicked()
+{
+    if (_currentResult?.Data == null || _tableView.Table == null)
+    {
+        return;
+    }
+
+    var selectedRow = _tableView.SelectedRow;
+    var selectedCol = _tableView.SelectedColumn;
+
+    var cellValue = _tableView.Table[selectedRow, selectedCol]?.ToString() ?? "";
+    var columnName = _tableView.Table.ColumnNames.ElementAt(selectedCol);
+
+    // Check if content is JSON
+    if (IsValidJson(cellValue))
+    {
+        ShowJsonTreeViewDialog(columnName, cellValue);
+    }
+    else
+    {
+        // Show a brief message that the cell doesn't contain JSON
+        MessageBox.Query("Not JSON", "The selected cell does not contain valid JSON data.", "OK");
+    }
+}
+
+private void ShowCellDetailDialog(string columnName, string cellValue)
+{
+    // Default text view dialog
+    var dialog = new Dialog()
+    {
+        Title = $"Cell Content: {columnName}",
+        Height = 20,
+        Width = Dim.Percent(80),
+        Modal = true,
+    };
+    var textView = new TextView()
+    {
+        X = 1,
+        Y = 1,
+        Width = Dim.Fill(1),
+        Height = Dim.Fill(2),
+        Text = cellValue,
+        ReadOnly = true,
+        WordWrap = true
+    };
+
+    dialog.Add(textView);
+    textView.SetFocus();
+
+    Application.Run(dialog);
+}
+
+private void ShowJsonTreeViewDialog(string columnName, string jsonContent)
+{
+    var dialog = new JsonTreeViewDialog(columnName, jsonContent);
+    Application.Run(dialog);
+}
+
+private static bool IsValidJson(string value)
+{
+    if (string.IsNullOrWhiteSpace(value))
+        return false;
+
+    value = value.Trim();
+    
+    // Quick check for JSON-like structure
+    if (!(value.StartsWith("{") && value.EndsWith("}")) &&
+        !(value.StartsWith("[") && value.EndsWith("]")))
+        return false;
+
+    try
+    {
+        System.Text.Json.JsonDocument.Parse(value);
+        return true;
+    }
+    catch (System.Text.Json.JsonException)
+    {
+        return false;
+    }
+    catch (Exception)
+    {
+        return false;
+    }
+}
+
+private void ToggleSearch()
+{
+    if (_searchVisible)
+    {
+        _searchField.SetFocus();
+    }
+    else
+    {
+        ShowSearch();
+    }
+}
+
+private void ShowSearch()
+{
+    if (_currentResult?.Data == null || _originalData == null)
+        return;
+
+    _searchVisible = true;
+    _searchLabel.Visible = true;
+    _searchField.Visible = true;
+    _searchField.SetFocus();
+}
+
+private void HideSearch()
+{
+    _searchVisible = false;
+    _searchLabel.Visible = false;
+    _searchField.Visible = false;
+    _searchField.Text = "";
+    if (_originalData != null)
+    {
+        _tableView.Table = new DataTableSource(_originalData);
+        UpdateStatusForOriginalData();
+    }
+    
+    _tableView.SetFocus();
+}
+
+private void OnSearchTextChanged(object? sender, EventArgs e)
+{
+    PerformSearch();
+}
+
+private void PerformSearch()
+{
+    if (_originalData == null || !_searchVisible)
+        return;
+
+    var searchText = _searchField.Text.ToString();
+    
+    if (string.IsNullOrWhiteSpace(searchText))
+    {
+        // Show all data when search is empty
+        _tableView.Table = new DataTableSource(_originalData);
+        UpdateStatusForOriginalData();
+        return;
+    }
+
+    try
+    {
+        // Create a filtered view of the data
+        var filteredTable = _originalData.Clone();
+        
+        foreach (DataRow row in _originalData.Rows)
+        {
+            bool rowMatches = false;
+            
+            // Check each column for the search text (case-insensitive)
+            foreach (var item in row.ItemArray)
+            {
+                var cellValue = item?.ToString() ?? "";
+                if (cellValue.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    rowMatches = true;
+                    break;
+                }
+            }
+            
+            if (rowMatches)
+            {
+                filteredTable.ImportRow(row);
+            }
+        }
+        
+        _tableView.Table = new DataTableSource(filteredTable);
+        UpdateStatusForFilteredData(filteredTable.Rows.Count, searchText);
+    }
+    catch (Exception ex)
+    {
+        // Hide table view and show error label for search errors
+        _tableView.Visible = false;
+        _errorLabel.Visible = true;
+        _errorLabel.Text = $"Search error: {ex.Message}";
+        _statusLabel.Text = "Error occurred during search";
+    }
+}
+
+private void UpdateStatusForOriginalData()
+{
+    if (_currentResult != null)
+    {
+        var statusText = $"Rows: {_currentResult.RowCount:N0} | Columns: {_currentResult.ColumnCount} | Duration: {_currentResult.Duration.TotalMilliseconds:F0}ms";
+        if (!string.IsNullOrEmpty(_currentResult.ClientRequestId))
+        {
+            statusText += $" | ClientRequestId: {_currentResult.ClientRequestId}";
+        }
+        _statusLabel.Text = statusText;
+    }
+}
+
+private void UpdateStatusForFilteredData(int filteredRowCount, string searchText)
+{
+    if (_currentResult != null)
+    {
+        var statusText = $"Filtered: {filteredRowCount:N0} of {_currentResult.RowCount:N0} rows | Search: \"{searchText}\" | Columns: {_currentResult.ColumnCount} | Duration: {_currentResult.Duration.TotalMilliseconds:F0}ms";
+        if (!string.IsNullOrEmpty(_currentResult.ClientRequestId))
+        {
+            statusText += $" | ClientRequestId: {_currentResult.ClientRequestId}";
+        }
+        _statusLabel.Text = statusText;
+    }
+}
+
+private void OnColumnSelectorClicked()
+{
+    if (_originalData == null) return;
+
+    var dialog = new ColumnSelectorDialog(_originalData, _selectedColumns);
+    Application.Run(dialog);
+
+    // Update selected columns and refresh display
+    _selectedColumns = dialog.SelectedColumns;
+    
+    if (_currentResult != null)
+    {
+        DisplayData(_currentResult);
+    }
+}
+
+private DataTable ApplyColumnFilter(DataTable sourceTable)
+{
+    if (_selectedColumns.Count == 0 || _selectedColumns.Count == sourceTable.Columns.Count)
+    {
+        // If no columns selected or all columns selected, return the original table
+        return sourceTable;
+    }
+
+    // Create a new table with only selected columns
+    var filteredTable = new DataTable();
+    
+    // Add selected columns to the new table
+    foreach (DataColumn column in sourceTable.Columns)
+    {
+        if (_selectedColumns.Contains(column.ColumnName))
+        {
+            filteredTable.Columns.Add(column.ColumnName, column.DataType);
+        }
+    }
+
+    // Copy rows with only selected columns
+    foreach (DataRow sourceRow in sourceTable.Rows)
+    {
+        var newRow = filteredTable.NewRow();
+        foreach (DataColumn column in filteredTable.Columns)
+        {
+            newRow[column.ColumnName] = sourceRow[column.ColumnName];
+        }
+        filteredTable.Rows.Add(newRow);
+    }
+
+return filteredTable;
+}
 }


### PR DESCRIPTION
Basically using file-scoped namespace instead of the legacy "{ }" syntax.
Example:
```csharp
namespace Foo
{
    void Bar()
    {
    }
}
```
Becomes:
```csharp
namespace Foo;

void Bar()
{
}
```